### PR TITLE
The Start Of An Economy

### DIFF
--- a/src/data/chemistry.js
+++ b/src/data/chemistry.js
@@ -2,7 +2,7 @@ const BASES = {
 	synthOxygen: {
 		item: "oxygen",
 		time: 1,
-		xp: 1,
+		xp: .1,
 		requiredLevel: 1,
 		requiredItems: {
 			power: 1
@@ -11,7 +11,7 @@ const BASES = {
 	synthOil: {
 		item: "oil",
 		time: 1,
-		xp: 1,
+		xp: .1,
 		requiredLevel: 1,
 		requiredItems: {
 			power: 1
@@ -20,7 +20,7 @@ const BASES = {
 	synthWater: {
 		item: "water",
 		time: 1,
-		xp: 1,
+		xp: .1,
 		requiredLevel: 1,
 		requiredItems: {
 			power: 1
@@ -29,7 +29,7 @@ const BASES = {
 	synthSacid: {
 		item: "sacid",
 		time: 1,
-		xp: 1,
+		xp: .1,
 		requiredLevel: 1,
 		requiredItems: {
 			power: 1
@@ -38,7 +38,7 @@ const BASES = {
 	synthMercury: {
 		item: "mercury",
 		time: 1,
-		xp: 1,
+		xp: .1,
 		requiredLevel: 1,
 		requiredItems: {
 			power: 1
@@ -47,7 +47,7 @@ const BASES = {
 	synthLithium: {
 		item: "lithium",
 		time: 1,
-		xp: 1,
+		xp: .1,
 		requiredLevel: 1,
 		requiredItems: {
 			power: 1
@@ -59,7 +59,7 @@ const POTIONS = {
 	synthFaunaPerfume: {
 		item: "potionMine",
 		time: 2,
-		xp: 20,
+		xp: 1,
 		requiredLevel: 5,
 		requiredItems: {
 			oil: 2,
@@ -70,7 +70,7 @@ const POTIONS = {
 	synthPotionEngi: {
 		item: "potionEngi",
 		time: 2,
-		xp: 20,
+		xp: 2,
 		requiredLevel: 10,
 		requiredItems: {
 			oil: 2,
@@ -81,7 +81,7 @@ const POTIONS = {
 	synthPotionFabrication: {
 		item: "potionEngi",
 		time: 2,
-		xp: 20,
+		xp: 3,
 		requiredLevel: 15,
 		requiredItems: {
 			oil: 2,
@@ -92,7 +92,7 @@ const POTIONS = {
 	synthPotionTide: {
 		item: "potionEngi",
 		time: 2,
-		xp: 20,
+		xp: 4,
 		requiredLevel: 20,
 		requiredItems: {
 			oil: 2,
@@ -103,7 +103,7 @@ const POTIONS = {
 	synthPotionTinker: {
 		item: "potionTinker",
 		time: 2,
-		xp: 20,
+		xp: 5,
 		requiredLevel: 25,
 		requiredItems: {
 			oil: 2,
@@ -114,7 +114,7 @@ const POTIONS = {
 	synthPotionBotany: {
 		item: "potionBotany",
 		time: 2,
-		xp: 20,
+		xp: 6,
 		requiredLevel: 30,
 		requiredItems: {
 			oil: 2,
@@ -125,7 +125,7 @@ const POTIONS = {
 	synthPotionCook: {
 		item: "potionCooking",
 		time: 2,
-		xp: 20,
+		xp: 7,
 		requiredLevel: 35,
 		requiredItems: {
 			oil: 2,
@@ -136,7 +136,7 @@ const POTIONS = {
 	synthPotionXeno: {
 		item: "potionXeno",
 		time: 2,
-		xp: 20,
+		xp: 8,
 		requiredLevel: 40,
 		requiredItems: {
 			oil: 2,
@@ -147,7 +147,7 @@ const POTIONS = {
 	synthPotionChem: {
 		item: "potionChem",
 		time: 2,
-		xp: 20,
+		xp: 9,
 		requiredLevel: 45,
 		requiredItems: {
 			oil: 2,
@@ -158,7 +158,7 @@ const POTIONS = {
 	synthPotionShit: {
 		item: "potionShit",
 		time: 2,
-		xp: 20,
+		xp: 10,
 		requiredLevel: 50,
 		requiredItems: {
 			lube: 2,
@@ -172,7 +172,7 @@ const POTIONS = {
 		xp: 5,
 		requiredLevel: 1,
 		requiredItems: {
-			power: 100
+			power: 10
 		}
 	}
 }

--- a/src/data/fabrication.js
+++ b/src/data/fabrication.js
@@ -191,7 +191,7 @@ const MECHS = {
 
 const ENERGY_AMMO = {
 	fabricateEammo1: {
-		time: .1,
+		time: .5,
 		item: "ammoE1",
 		icon: require("@/assets/art/combat/items/ammo_e1.png"),
 		xp: 1,
@@ -201,7 +201,7 @@ const ENERGY_AMMO = {
 		}
 	},
 	fabricateEammo2: {
-		time: .1,
+		time: .5,
 		item: "ammoE2",
 		icon: require("@/assets/art/combat/items/ammo_e2.png"),
 		xp: 2,
@@ -211,7 +211,7 @@ const ENERGY_AMMO = {
 		}
 	},
 	fabricateEammo3: {
-		time: .1,
+		time: .5,
 		item: "ammoE3",
 		icon: require("@/assets/art/combat/items/ammo_e3.png"),
 		xp: 3,
@@ -224,7 +224,7 @@ const ENERGY_AMMO = {
 
 const BALLISTIC_AMMO = {
 	fabricateBammo1: {
-		time: .1,
+		time: .5,
 		item: "ammoB1",
 		icon: require("@/assets/art/combat/items/ammo_b1.png"),
 		xp: 1,
@@ -234,7 +234,7 @@ const BALLISTIC_AMMO = {
 		}
 	},
 	fabricateBammo2: {
-		time: .1,
+		time: .5,
 		item: "ammoB2",
 		icon: require("@/assets/art/combat/items/ammo_b2.png"),
 		xp: 2,
@@ -244,7 +244,7 @@ const BALLISTIC_AMMO = {
 		}
 	},
 	fabricateBammo3: {
-		time: .1,
+		time: .5,
 		item: "ammoB3",
 		icon: require("@/assets/art/combat/items/ammo_b3.png"),
 		xp: 3,

--- a/src/data/items/foodBotany.js
+++ b/src/data/items/foodBotany.js
@@ -6,7 +6,7 @@ export default {
 	},
 	potato: {
 		name: "Potato",
-		sellPrice: 1,
+		sellPrice: 5,
 		icon: require("@/assets/art/botany/PlantPotato.png"),
 		healAmount: 5,
 		stats: {
@@ -18,7 +18,7 @@ export default {
 	},
 	tomato: {
 		name: "Tomato",
-		sellPrice: 2,
+		sellPrice: 5,
 		icon: require("@/assets/art/botany/PlantTomato.png"),
 		healAmount: 5,
 		stats: {
@@ -30,7 +30,7 @@ export default {
 	},
 	banana: {
 		name: "Banana",
-		sellPrice: 5,
+		sellPrice: 14,
 		icon: require("@/assets/art/botany/PlantBanana.png"),
 		healAmount: 5,
 		stats: {
@@ -42,7 +42,7 @@ export default {
 	},
 	flowersun: {
 		name: "Sunflower",
-		sellPrice: 8,
+		sellPrice: 14,
 		icon: require("@/assets/art/botany/PlantFlowersun.png"),
 		healAmount: 5,
 		stats: {
@@ -54,7 +54,7 @@ export default {
 	},
 	mushroom: {
 		name: "Glowshroom",
-		sellPrice: 10,
+		sellPrice: 25,
 		icon: require("@/assets/art/botany/PlantShroomglow.png"),
 		healAmount: 5,
 		stats: {
@@ -66,7 +66,7 @@ export default {
 	},
 	pepper: {
 		name: "Hot Pepper",
-		sellPrice: 10,
+		sellPrice: 25,
 		icon: require("@/assets/art/botany/PlantPepperhot.png"),
 		healAmount: 5,
 		stats: {
@@ -78,7 +78,7 @@ export default {
 	},
 	potatobattery: {
 		name: "Potato Battery",
-		sellPrice: 12,
+		sellPrice: 37,
 		icon: require("@/assets/art/botany/PlantPotatobattery.png"),
 		healAmount: 10,
 		stats: {
@@ -90,7 +90,7 @@ export default {
 	},
 	tomatoblue: {
 		name: "Blue Tomato",
-		sellPrice: 23,
+		sellPrice: 37,
 		icon: require("@/assets/art/botany/PlantTomatoblue.png"),
 		healAmount: 10,
 		stats: {
@@ -102,7 +102,7 @@ export default {
 	},
 	bananamime: {
 		name: "...",
-		sellPrice: 27,
+		sellPrice: 45,
 		icon: require("@/assets/art/botany/PlantBananamime.png"),
 		healAmount: 10,
 		stats: {
@@ -114,7 +114,7 @@ export default {
 	},
 	flowermoon: {
 		name: "Moonflower",
-		sellPrice: 30,
+		sellPrice: 45,
 		icon: require("@/assets/art/botany/PlantFlowermoon.png"),
 		healAmount: 10,
 		stats: {
@@ -126,7 +126,7 @@ export default {
 	},
 	mushroomred: {
 		name: "Glowcap",
-		sellPrice: 10,
+		sellPrice: 52,
 		icon: require("@/assets/art/botany/PlantShroomred.png"),
 		healAmount: 10,
 		stats: {
@@ -138,7 +138,7 @@ export default {
 	},
 	peppercold: {
 		name: "Ice Pepper",
-		sellPrice: 44,
+		sellPrice: 52,
 		icon: require("@/assets/art/botany/PlantPeppercold.png"),
 		healAmount: 10,
 		stats: {
@@ -150,7 +150,7 @@ export default {
 	},
 	orange: {
 		name: "Orange",
-		sellPrice: 12,
+		sellPrice: 61,
 		icon: require("@/assets/art/botany/PlantOrange.png"),
 		healAmount: 15,
 		stats: {
@@ -162,7 +162,7 @@ export default {
 	},
 	tomatobluespace: {
 		name: "Bluespace Tomato",
-		sellPrice: 23,
+		sellPrice: 61,
 		icon: require("@/assets/art/botany/PlantTomatobluespace_anim.gif"),
 		healAmount: 15,
 		stats: {
@@ -176,7 +176,7 @@ export default {
 		name: "Blue Banana",
 		sellPrice: 27,
 		icon: require("@/assets/art/botany/PlantBananablue.png"),
-		healAmount: 15,
+		healAmount: 66,
 		stats: {
 			maxHealth: 5,
 			evasion: 10,
@@ -186,7 +186,7 @@ export default {
 	},
 	flowernova: {
 		name: "Novaflower",
-		sellPrice: 30,
+		sellPrice: 66,
 		icon: require("@/assets/art/botany/PlantFlowernova.png"),
 		healAmount: 15,
 		stats: {
@@ -198,7 +198,7 @@ export default {
 	},
 	mushroomshadow: {
 		name: "Shadowshroom",
-		sellPrice: 10,
+		sellPrice: 71,
 		icon: require("@/assets/art/botany/PlantShroomshadow.png"),
 		healAmount: 15,
 		stats: {
@@ -210,7 +210,7 @@ export default {
 	},
 	pepperghost: {
 		name: "Ghost Pepper",
-		sellPrice: 44,
+		sellPrice: 71,
 		icon: require("@/assets/art/botany/PlantPepperghost.png"),
 		healAmount: 15,
 		stats: {
@@ -222,7 +222,7 @@ export default {
 	},
 	orange3d: {
 		name: "Multidimensional Orange",
-		sellPrice: 12,
+		sellPrice: 83,
 		icon: require("@/assets/art/botany/PlantOrange3d_anim.gif"),
 		healAmount: 20,
 		stats: {
@@ -234,7 +234,7 @@ export default {
 	},
 	tomatokiller: {
 		name: "Killer Tomato",
-		sellPrice: 23,
+		sellPrice: 83,
 		icon: require("@/assets/art/botany/PlantTomatokiller.png"),
 		healAmount: 5,
 		stats: {

--- a/src/data/items/foodCooking.js
+++ b/src/data/items/foodCooking.js
@@ -1,43 +1,43 @@
 export default {
 	foodMeatH: {
 		name: "Human Meat",
-		sellPrice: 0,
+		sellPrice: 10,
 		icon: require("@/assets/art/cooking/meatHuman.png"),
-		healAmount: 15,
+		healAmount: 10,
 		stats: {
-			maxHealth: 5,
-			evasion: -5,
-			precision: 0,
-			power: 10,
+			maxHealth: 2,
+			evasion: -1,
+			precision: 2,
+			power: -1,
 		},
 	},
 	foodMeatZ: {
 		name: "Alien Meat",
-		sellPrice: 0,
+		sellPrice: 10,
 		icon: require("@/assets/art/cooking/meatAlien.png"),
-		healAmount: 15,
+		healAmount: 10,
 		stats: {
-			maxHealth: 5,
-			evasion: -5,
-			precision: 0,
-			power: 10,
+			maxHealth: 2,
+			evasion: 2,
+			precision: -1,
+			power: -1,
 		},
 	},
 	foodMeatA: {
 		name: "Animal Meat",
-		sellPrice: 0,
+		sellPrice: 10,
 		icon: require("@/assets/art/cooking/meatAnimal.png"),
-		healAmount: 15,
+		healAmount: 10,
 		stats: {
-			maxHealth: 0,
-			evasion: 0,
-			precision: 0,
-			power: 5,
+			maxHealth: 2,
+			evasion: -1,
+			precision: -1,
+			power: 2,
 		},
 	},
 	foodPasta1: {
 		name: "Pasta",
-		sellPrice: 0,
+		sellPrice: 8,
 		icon: require("@/assets/art/cooking/pasta1.png"),
 		healAmount: 3,
 		stats: {
@@ -49,7 +49,7 @@ export default {
 	},
 	foodPasta2: {
 		name: "Double Pasta",
-		sellPrice: 0,
+		sellPrice: 45,
 		icon: require("@/assets/art/cooking/pasta2.png"),
 		healAmount: 6,
 		stats: {
@@ -61,7 +61,7 @@ export default {
 	},
 	foodPasta3: {
 		name: "Triple Pasta",
-		sellPrice: 0,
+		sellPrice: 113,
 		icon: require("@/assets/art/cooking/pasta3.png"),
 		healAmount: 9,
 		stats: {
@@ -73,7 +73,7 @@ export default {
 	},
 	foodPasta4: {
 		name: "Pasta Tower",
-		sellPrice: 0,
+		sellPrice: 211,
 		icon: require("@/assets/art/cooking/pasta4.png"),
 		healAmount: 12,
 		stats: {
@@ -85,7 +85,7 @@ export default {
 	},
 	foodPasta5: {
 		name: "InSPIREd Pasta",
-		sellPrice: 0,
+		sellPrice: 338,
 		icon: require("@/assets/art/cooking/pasta5.png"),
 		healAmount: 15,
 		stats: {
@@ -97,7 +97,7 @@ export default {
 	},
 	foodPasta6: {
 		name: "Babel Pasta",
-		sellPrice: 0,
+		sellPrice: 496,
 		icon: require("@/assets/art/cooking/pasta6.png"),
 		healAmount: 18,
 		stats: {
@@ -109,7 +109,7 @@ export default {
 	},
 	foodPer1: {
 		name: "Hot Potato Stew",
-		sellPrice: 0,
+		sellPrice: 20,
 		icon: require("@/assets/art/cooking/stew1.png"),
 		healAmount: 15,
 		stats: {
@@ -121,7 +121,7 @@ export default {
 	},
 	foodPer2: {
 		name: "Tingle Soup",
-		sellPrice: 0,
+		sellPrice: 102,
 		icon: require("@/assets/art/cooking/stew2.png"),
 		healAmount: 30,
 		stats: {
@@ -133,7 +133,7 @@ export default {
 	},
 	foodPer3: {
 		name: "Dad's Soup",
-		sellPrice: 0,
+		sellPrice: 171,
 		icon: require("@/assets/art/cooking/stew3.png"),
 		healAmount: 45,
 		stats: {
@@ -145,7 +145,7 @@ export default {
 	},
 	foodPow1: {
 		name: "Donkpocket",
-		sellPrice: 0,
+		sellPrice: 26,
 		icon: require("@/assets/art/cooking/donk1.png"),
 		healAmount: 15,
 		stats: {
@@ -157,7 +157,7 @@ export default {
 	},
 	foodPow2: {
 		name: "Berrypocket",
-		sellPrice: 0,
+		sellPrice: 108,
 		icon: require("@/assets/art/cooking/donk2.png"),
 		healAmount: 30,
 		stats: {
@@ -169,7 +169,7 @@ export default {
 	},
 	foodPow3: {
 		name: "Dankpocket",
-		sellPrice: 0,
+		sellPrice: 177,
 		icon: require("@/assets/art/cooking/donk3.png"),
 		healAmount: 45,
 		stats: {
@@ -181,7 +181,7 @@ export default {
 	},
 	foodEva1: {
 		name: "Creampie",
-		sellPrice: 0,
+		sellPrice: 31,
 		icon: require("@/assets/art/cooking/pie1.png"),
 		healAmount: 15,
 		stats: {
@@ -193,7 +193,7 @@ export default {
 	},
 	foodEva2: {
 		name: "Moonpie",
-		sellPrice: 0,
+		sellPrice: 115,
 		icon: require("@/assets/art/cooking/pie2.png"),
 		healAmount: 30,
 		stats: {
@@ -205,7 +205,7 @@ export default {
 	},
 	foodEva3: {
 		name: "Senpai",
-		sellPrice: 0,
+		sellPrice: 183,
 		icon: require("@/assets/art/cooking/pie3.png"),
 		healAmount: 45,
 		stats: {
@@ -217,7 +217,7 @@ export default {
 	},
 	foodHuman1: {
 		name: "Spicy Burger",
-		sellPrice: 0,
+		sellPrice: 48,
 		icon: require("@/assets/art/cooking/burger1.png"),
 		healAmount: 0,
 		stats: {
@@ -229,7 +229,7 @@ export default {
 	},
 	foodHuman2: {
 		name: "Slippery Burger",
-		sellPrice: 0,
+		sellPrice: 122,
 		icon: require("@/assets/art/cooking/burger2.png"),
 		healAmount: 20,
 		stats: {
@@ -241,7 +241,7 @@ export default {
 	},
 	foodHuman3: {
 		name: "Blue Burger",
-		sellPrice: 0,
+		sellPrice: 160,
 		icon: require("@/assets/art/cooking/burger3.png"),
 		healAmount: 30,
 		stats: {
@@ -253,7 +253,7 @@ export default {
 	},
 	foodHuman4: {
 		name: "Ghost Burger",
-		sellPrice: 0,
+		sellPrice: 185,
 		icon: require("@/assets/art/cooking/burger4_anim.gif"),
 		healAmount: 30,
 		stats: {
@@ -265,7 +265,7 @@ export default {
 	},
 	foodAnimal1: {
 		name: "Pizza",
-		sellPrice: 0,
+		sellPrice: 63,
 		icon: require("@/assets/art/cooking/animal1.png"),
 		healAmount: 10,
 		stats: {
@@ -277,7 +277,7 @@ export default {
 	},
 	foodAnimal2: {
 		name: "Moon Pizza",
-		sellPrice: 0,
+		sellPrice: 111,
 		icon: require("@/assets/art/cooking/animal2.png"),
 		healAmount: 20,
 		stats: {
@@ -289,7 +289,7 @@ export default {
 	},
 	foodAnimal3: {
 		name: "Bluespace Pizza",
-		sellPrice: 0,
+		sellPrice: 162,
 		icon: require("@/assets/art/cooking/animal3.png"),
 		healAmount: 30,
 		stats: {
@@ -301,7 +301,7 @@ export default {
 	},
 	foodAnimal4: {
 		name: "Nova Pizza",
-		sellPrice: 0,
+		sellPrice: 187,
 		icon: require("@/assets/art/cooking/animal4.png"),
 		healAmount: 30,
 		stats: {
@@ -313,7 +313,7 @@ export default {
 	},
 	foodAlien1: {
 		name: "Fesh 'Shishi'",
-		sellPrice: 0,
+		sellPrice: 69,
 		icon: require("@/assets/art/cooking/Alien1.png"),
 		healAmount: 10,
 		stats: {
@@ -325,7 +325,7 @@ export default {
 	},
 	foodAlien2: {
 		name: "Finger Food",
-		sellPrice: 0,
+		sellPrice: 122,
 		icon: require("@/assets/art/cooking/Alien2.png"),
 		healAmount: 20,
 		stats: {
@@ -337,7 +337,7 @@ export default {
 	},
 	foodAlien3: {
 		name: "Fush n Chips",
-		sellPrice: 0,
+		sellPrice: 168,
 		icon: require("@/assets/art/cooking/Alien3.png"),
 		healAmount: 30,
 		stats: {
@@ -349,7 +349,7 @@ export default {
 	},
 	foodAlien4: {
 		name: "Fried Friend",
-		sellPrice: 0,
+		sellPrice: 197,
 		icon: require("@/assets/art/cooking/Alien4.png"),
 		healAmount: 30,
 		stats: {

--- a/src/data/items/resourceGraytiding.js
+++ b/src/data/items/resourceGraytiding.js
@@ -1,17 +1,17 @@
 export default {
     junk: {
 		name: "Junk",
-		sellPrice: 5,
+		sellPrice: 150,
 		icon: require("@/assets/art/graytiding/junk.png")
 	},
 	armorjunk: {
 		name: "Protective Junk",
-		sellPrice: 5,
+		sellPrice: 150,
 		icon: require("@/assets/art/graytiding/armorjunk.png")
 	},
 	spacejunk: {
 		name: "Airtight Junk",
-		sellPrice: 5,
+		sellPrice: 150,
 		icon: require("@/assets/art/graytiding/spacejunk.png")
 	},
 }

--- a/src/data/items/resourceMining.js
+++ b/src/data/items/resourceMining.js
@@ -1,52 +1,52 @@
 export default {
 	iron: {
 		name: "Iron",
-		sellPrice: 1,
+		sellPrice: 2,
 		icon: require("@/assets/art/mining/SheetIron.png")
 	},
 	glass: {
 		name: "Glass",
-		sellPrice: 2,
+		sellPrice: 10,
 		icon: require("@/assets/art/mining/SheetGlass.png")
 	},
 	silver: {
 		name: "Silver",
-		sellPrice: 5,
+		sellPrice: 25,
 		icon: require("@/assets/art/mining/SheetSilver.png")
 	},
 	gold: {
 		name: "Gold",
-		sellPrice: 8,
+		sellPrice: 45,
 		icon: require("@/assets/art/mining/SheetGold.png")
 	},
 	titanium: {
 		name: "Titanium",
-		sellPrice: 10,
+		sellPrice: 70,
 		icon: require("@/assets/art/mining/SheetTitanium.png")
 	},
 	uranium: {
 		name: "Uranium",
-		sellPrice: 12,
+		sellPrice: 100,
 		icon: require("@/assets/art/mining/SheetUranium.png")
 	},
 	plasma: {
 		name: "Plasma",
-		sellPrice: 23,
+		sellPrice: 135,
 		icon: require("@/assets/art/mining/SheetPlasma.png")
 	},
 	diamond: {
 		name: "Diamond",
-		sellPrice: 27,
+		sellPrice: 175,
 		icon: require("@/assets/art/mining/SheetDiamond.png")
 	},
 	bluespace: {
 		name: "Bluespace Crystal",
-		sellPrice: 30,
+		sellPrice: 220,
 		icon: require("@/assets/art/mining/SheetBluespace.png")
 	},
 	bananium: {
 		name: "Bananium",
-		sellPrice: 44,
+		sellPrice: 325,
 		healAmount: 69,
 		icon: require("@/assets/art/mining/SheetBanana.png")
 	},

--- a/src/data/items/resourceTinkering.js
+++ b/src/data/items/resourceTinkering.js
@@ -6,7 +6,7 @@ export default {
 	},
 	burnjunk: {
 		name: "Flammable Junk",
-		sellPrice: 5,
+		sellPrice: 200,
 		icon: require("@/assets/art/tinkering/burnjunk.png")
 	},
 }

--- a/src/data/items/slotHand.js
+++ b/src/data/items/slotHand.js
@@ -435,7 +435,7 @@ export default {
 	},
 	gunE1: {
 		name: "Kinetic Accelerator",
-		sellPrice: 22,
+		sellPrice: 155,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_PKA.png"),
 		overlay: require("@/assets/art/combat/items/gune_PKA_overlay.png"),
@@ -452,7 +452,7 @@ export default {
 	},
 	gunE2: {
 		name: "Advanced Kinetic Accelerator",
-		sellPrice: 75,
+		sellPrice: 203,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_PKA+.png"),
 		overlay: require("@/assets/art/combat/items/gune_PKA+_overlay.png"),
@@ -469,7 +469,7 @@ export default {
 	},
 	gunE3: {
 		name: "Plasma Cutter",
-		sellPrice: 80,
+		sellPrice: 410,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_cutter.png"),
 		overlay: require("@/assets/art/combat/items/gune_cutter_overlay.png"),
@@ -486,7 +486,7 @@ export default {
 	},	
 	gunE4: {
 		name: "Laser Gun",
-		sellPrice: 180,
+		sellPrice: 765,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_laser.png"),
 		overlay: require("@/assets/art/combat/items/gune_laser_overlay.png"),
@@ -503,7 +503,7 @@ export default {
 	},
 	gunE5: {
 		name: "Tesla Rifle",
-		sellPrice: 250,
+		sellPrice: 983,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_tesla.png"),
 		overlay: require("@/assets/art/combat/items/gune_tesla_overlay.png"),
@@ -520,7 +520,7 @@ export default {
 	},
 	gunE6: {
 		name: "Energy Gun",
-		sellPrice: 210,
+		sellPrice: 1220,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_energy.png"),
 		overlay: require("@/assets/art/combat/items/gune_energy_overlay.png"),
@@ -537,7 +537,7 @@ export default {
 	},
 	gunE7: {
 		name: "Wartime Rifle",
-		sellPrice: 0,
+		sellPrice: 1453,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gune_caplaser.png"),
 		overlay: require("@/assets/art/combat/items/gune_caplaser_overlay.png"),
@@ -554,7 +554,7 @@ export default {
 	},
 	gunB1: {
 		name: "Pipe Shotgun",
-		sellPrice: 18,
+		sellPrice: 74,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot1.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot1_overlay.png"),
@@ -571,7 +571,7 @@ export default {
 	},
 	gunB2: {
 		name: "Double Barreled Shotgun",
-		sellPrice: 75,
+		sellPrice: 152,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot2.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot4_overlay.png"),
@@ -588,7 +588,7 @@ export default {
 	},
 	gunB3: {
 		name: "Cycling Shotgun",
-		sellPrice: 42,
+		sellPrice: 273,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot3.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot4_overlay.png"),
@@ -605,7 +605,7 @@ export default {
 	},	
 	gunB4: {
 		name: "Riot Shotgun",
-		sellPrice: 64,
+		sellPrice: 572,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot4.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot4_overlay.png"),
@@ -622,7 +622,7 @@ export default {
 	},
 	gunB5: {
 		name: "Sawed Off Shotgun",
-		sellPrice: 125,
+		sellPrice: 623,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot5.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot6_overlay.png"),
@@ -639,7 +639,7 @@ export default {
 	},
 	gunB6: {
 		name: "Compact Shotgun",
-		sellPrice: 86,
+		sellPrice: 783,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot6.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot6_overlay.png"),
@@ -656,7 +656,7 @@ export default {
 	},
 	gunB7: {
 		name: "Combat Shotgun",
-		sellPrice: 104,
+		sellPrice: 921,
 		equipmentSlot: "hand",
 		icon: require("@/assets/art/combat/items/gunb_shot7.png"),
 		overlay: require("@/assets/art/combat/items/gunb_shot7_overlay.png"),

--- a/src/data/xenobiology.js
+++ b/src/data/xenobiology.js
@@ -7,6 +7,14 @@ export const ACTIONS = {
 		requiredLevel: 1,
 		tier: 1
 	},
+	splitGrey40: {
+	 	time: 1,
+ 		item: "slimeGrey",
+ 		icon: require("@/assets/art/xenobio/SlimeGrey.gif"),
+ 		xp: -5,
+		requiredLevel: 40,
+		tier: 0
+	},
 	splitOrange: {
 		time: 5,
 		item: "slimeOrange",
@@ -183,13 +191,6 @@ export const ACTIONS = {
 		},
 		tier: 5
 	},
-	// splitGrey40: {
-	// 	time: 1,
-	// 	item: "slimeGrey",
-	// 	icon: require("@/assets/art/xenobio/SlimeGrey.gif"),
-	// 	xp: -5,
-	// 	requiredLevel: 40
-	// },
 	splitOil: {
 		time: 5,
 		item: "slimeOil",


### PR DESCRIPTION
The following skills have had economy values added. The income is relatively even between all jobs at 1 per second per level of skill. This is BEFORE any upgrades are accounted for so I'm sure they'll make things interesting (I'm counting on it).

**Mining**
All
**Fabrication**
Just the guns
**Botany**
This was a fun one, since it tried to take into account seeds and the fact that they grow in batches
**Cooking**
Also fun because it was taking into account Botany prices which were all over the place.
**Greytiding**
Despite being unlocked at level 1, junk is treated as a level 25 item. This is because it never improves. Great money maker at the start of the game, worse later.
**Tinkering** 
Flammable junk only, The rest of the skill needs a look over on xp values.

**Xenobiology**
Readds the tier zero slime. No costs given.