### PR TITLE
Early combat buffs, minor fixes

### DIFF
--- a/src/data/enemies.js
+++ b/src/data/enemies.js
@@ -45,7 +45,7 @@ Object.values(ENEMIES).forEach(enemy => {
 		chance: 1,
 		items: {
 			id: "money",
-			count: [0, robustness * 3]
+			count: [0, robustness * 5]
 		}
 	});
 });

--- a/src/data/engineering.js
+++ b/src/data/engineering.js
@@ -44,7 +44,7 @@ const RENEWABLE_ACTIONS = {
 		},
 		icon: require("@/assets/art/engineering/generator_anim2.gif"),
 		xp: 7,
-		requiredLevel: 14,
+		requiredLevel: 25,
 		requiredItems: {
 			power: 4
 		}
@@ -53,7 +53,7 @@ const RENEWABLE_ACTIONS = {
 
 const RESOURCE_CONSUMING_ACTIONS = {
 	engOil: {
-		time: 2.5,
+		time: 5,
 		name: "Oil Barrel",
 		items: {
 			id: "power",

--- a/src/data/graytiding.js
+++ b/src/data/graytiding.js
@@ -191,7 +191,7 @@ const ACTIONS = {
 				itemTable: [
 					{
 						id: "plantSeed",
-						count: [0, 2],
+						count: [2, 5],
 						weight: 499
 					}, {
 						id: "limbBlack",

--- a/src/data/items/slotChest.js
+++ b/src/data/items/slotChest.js
@@ -291,7 +291,7 @@ Object.values(BRUTEARMOR).forEach(brutearmor => {
 	brutearmor.equipmentSlot = "chest";
 	let bruteConstant = Math.max(10, brutearmor.requires.evasion);
 
-	brutearmor.stats.maxHealth = Math.trunc(bruteConstant * 1.5);
+	brutearmor.stats.maxHealth = Math.trunc(bruteConstant * 2.5) + 10;
 	brutearmor.stats.power = Math.ceil(bruteConstant * .05);
 	brutearmor.stats.evasion = Math.ceil(bruteConstant * 0.45);
 	brutearmor.stats.bruteProtection = Math.round(bruteConstant * .2) + 2;
@@ -301,7 +301,7 @@ Object.values(BURNARMOR).forEach(burnarmor => {
 	burnarmor.equipmentSlot = "chest";
 	let burnConstant = Math.max(5, burnarmor.requires.evasion);
 
-	burnarmor.stats.maxHealth = Math.trunc(burnConstant * 1.5);
+	burnarmor.stats.maxHealth = Math.trunc(burnConstant * 2.5) + 10;
 	burnarmor.stats.precision = Math.ceil(burnConstant * .05);
 	burnarmor.stats.evasion = Math.ceil(burnConstant * 0.4);
 	burnarmor.stats.burnProtection = Math.round(burnConstant * .3) + 3;
@@ -315,7 +315,7 @@ Object.values(MECHS).forEach(mech => {
 	mech.requires.evasion = Math.trunc(mech.requires.fabrication / 2);
 	if (Object.values(mech.stats).length > 0) return;
 	mech.stats.moveTime = 3;
-	mech.stats.maxHealth = mech.requires.fabrication * 3;
+	mech.stats.maxHealth = (mech.requires.fabrication * 3.5) + 20;
 	mech.stats.precision = Math.ceil(mech.requires.fabrication * .2);
 	mech.stats.power = Math.ceil(mech.requires.fabrication * .2);
 	mech.stats.evasion = Math.trunc(mech.requires.fabrication * .1);

--- a/src/data/items/slotCompanion.js
+++ b/src/data/items/slotCompanion.js
@@ -145,9 +145,9 @@ const SLIMES = {
 		name: "Pet Mouse",
 		sellPrice: 1000,
 		icon: require("@/assets/art/combat/enemies/mouse.png"),
-		tier: 7,
+		tier: 0,
 		stats: {
-			evasion: 10,
+			evasion: 5,
 			maxHealth: 50
 		}
 	},
@@ -155,9 +155,9 @@ const SLIMES = {
 		name: "Pet Corgi",
 		sellPrice: 1000,
 		icon: require("@/assets/art/combat/enemies/Ian.png"),
-		tier: 7,
+		tier: 0,
 		stats: {
-			precision: 10,
+			precision: 5,
 			maxHealth: 50
 		}
 	},
@@ -165,9 +165,9 @@ const SLIMES = {
 		name: "Pet Goat",
 		sellPrice: 1000,
 		icon: require("@/assets/art/combat/enemies/pete.png"),
-		tier: 7,
+		tier: 0,
 		stats: {
-			power: 10,
+			power: 5,
 			maxHealth: 50
 		}
 	},
@@ -175,7 +175,7 @@ const SLIMES = {
 		name: "Pet Bee",
 		sellPrice: 1000,
 		icon: require("@/assets/art/combat/enemies/bee_anim.gif"),
-		tier: 10,
+		tier: 0,
 		stats: {
 			protection: 1,
 			precision: 1,
@@ -188,9 +188,9 @@ const SLIMES = {
 		name: "Mine Bot",
 		sellPrice: 300,
 		icon: require("@/assets/art/xenobio/CompanionMining.png"),
-		tier: 7,
+		tier: 0,
 		stats: {
-			protection: 10,
+			protection: 5,
 			maxHealth: 100
 		}
 	},
@@ -198,12 +198,12 @@ const SLIMES = {
 		name: "Killer Tomato",
 		sellPrice: 83,
 		icon: require("@/assets/art/botany/PlantTomatokiller.png"),
-		tier: 7,
+		tier: 5,
 		stats: {
 			maxHealth: 20,
-			evasion: 10,
-			precision: 10,
-			power: 10,
+			evasion: 5,
+			precision: 5,
+			power: 5,
 			command: -10
 		},
 	}


### PR DESCRIPTION
Fix Oil Barrel time, Generator 2 level requirement
BUFFS Chest slots HP. 10 to 60 more HP depending on the level (20-55 for mechs)
BUFFS non xenobiology run chances SIGNIFICANTLY
BUFFS seeds from greytiding slightly
Nerfs non slime companion stats.
Buffs coin drops from enemies from 0-3 to 0-5 multiplied by robustness