### PR TITLE
Chest sell prices, Flame junk, and Combat Drop Tables

### DIFF
--- a/src/data/enemies/arrivalLounge.js
+++ b/src/data/enemies/arrivalLounge.js
@@ -5,9 +5,9 @@ export default {
 		stats: {
 			maxHealth: 18,
 			attackSpeed: 1.6,
-			precision: 8,
+			precision: 3,
 			power: 4,
-			evasion: 7,
+			evasion: 4,
 			damageType: "brute",
 			burnProtection: 20
 		},
@@ -55,9 +55,9 @@ export default {
 		stats: {
 			maxHealth: 20,
 			attackSpeed: 1.6,
-			precision: 6,
+			precision: 5,
 			power: 7,
-			evasion: 13,
+			evasion: 9,
 			damageType: "burn",
 			bruteProtection: 20
 		},

--- a/src/data/enemies/bridge.js
+++ b/src/data/enemies/bridge.js
@@ -17,17 +17,18 @@ export default {
 				chance: 0.5,
 				itemTable: [
 					{
+						id: 'ammoEnergy3',
+						count: 4,
+						weight: 21
+					},
+					{
 						id: 'armorBrute4',
-						weight: 1
+						weight: 4
 					},
 					{
 						id: 'faceSecGlassess',
 						weight: 1
 					},
-					{
-						id: 'ammoEnergy3',
-						weight: 1
-					}
 				]
 			},
 			{
@@ -54,18 +55,26 @@ export default {
 				chance: 0.5,
 				itemTable: [
 					{
+						id: 'pillPumpup',
+						weight: 7
+					},
+					{
+						id: 'pillCrank',
+						weight: 4
+					},
+					{
+						id: 'meleeSharp5',
+						weight: 2
+					},
+					{
 						id: 'faceGas',
 						weight: 1
 					},
-					{
-						id: 'gold',
-						weight: 1
-					},
-					{
-						id: 'jumpsuitGraytide',
-						weight: 1
-					}
 				]
+			},
+			{
+				chance: .02,
+				item: "jumpsuitGraytide"
 			},
 			{
 				chance: 1,
@@ -92,7 +101,13 @@ export default {
 				itemTable: [
 					{
 						id: 'wire',
-						weight: 1
+						count: [2, 5],
+						weight: 10
+					},
+					{
+						id: 'money',
+						count: [220, 660],
+						weight: 8
 					},
 					{
 						id: 'ticket3',
@@ -102,7 +117,7 @@ export default {
 					{
 						id: 'titanium',
 						weight: 1
-					}
+					},
 				]
 			},
 			{

--- a/src/data/enemies/maintenance.js
+++ b/src/data/enemies/maintenance.js
@@ -24,7 +24,7 @@ export default {
 					{
 						id: "wire",
 						weight: 150,
-						count: [1, 20]
+						count: [1, 3]
 					},
 					{
 						id: "foodMeatA",

--- a/src/data/enemies/medical.js
+++ b/src/data/enemies/medical.js
@@ -21,13 +21,18 @@ export default {
 					},
 					{
 						id: 'ammoBallistic3',
+						count: 8,
 						weight: 1
 					},
 					{
-						id: 'jumpsuitChemistry',
+						id: 'potionChemistry',
 						weight: 1
 					}
 				]
+			},
+			{
+				chance: .02,
+				item: "jumpsuitChemistry"
 			},
 			{
 				chance: 1,
@@ -60,10 +65,14 @@ export default {
 						weight: 1
 					},
 					{
-						id: 'jumpsuitMedical',
+						id: 'potionTinkering',
 						weight: 1
 					}
 				]
+			},
+			{
+				chance: .02,
+				item: "jumpsuitMedical"
 			},
 			{
 				chance: 1,

--- a/src/data/enemies/science.js
+++ b/src/data/enemies/science.js
@@ -52,18 +52,19 @@ export default {
 				chance: 0.5,
 				itemTable: [
 					{
-						id: 'gold',
-						weight: 1
+						id: 'wire',
+						count: [1,2],
+						weight: 7
 					},
 					{
-						id: 'gold',
-						weight: 1
+						id: 'meleeSharp3',
+						weight: 4
 					},
-					{
-						id: 'jumpsuitFabrication',
-						weight: 1
-					}
 				]
+			},
+			{
+				chance: .02,
+				item: "jumpsuitFabrication"
 			},
 			{
 				chance: 1,
@@ -101,22 +102,18 @@ export default {
 				chance: 0.5,
 				itemTable: [
 					{
-						id: 'ripley',
-						weight: 1
-					},
-					{
 						id: 'wire',
-						weight: 1
+						weight: 54
 					},
 					{
 						id: 'meleeToolbox6',
-						weight: 1
-					}
+						weight: 8
+					},
+					{
+						id: 'ripley',
+						weight: 5
+					},
 				]
-			},
-			{
-				chance: .2,
-				item: "armorBrute6"
 			},
 			{
 				chance: 1,
@@ -126,7 +123,7 @@ export default {
 						weight: 1
 					},
 					{
-						id: 'Plasma',
+						id: 'plasma',
 						weight: 1
 					}
 				]
@@ -151,17 +148,17 @@ export default {
 				itemTable: [
 					{
 						id: 'bluespace',
-						weight: 1
+						weight: 19
 					},
 					{
 						id: 'ticket3',
 						count: [1, 2],
-						weight: 1
+						weight: 3
 					},
 					{
-						id: 'gold',
-						weight: 1
-					}
+						id: "armorBrute6",
+						weight: 2
+					},
 				]
 			},
 			{

--- a/src/data/enemies/virology.js
+++ b/src/data/enemies/virology.js
@@ -5,9 +5,9 @@ export default {
 		stats: {
 			maxHealth: 310,
 			attackSpeed: 3.0,
-			precision: 86,
-			power: 91,
-			evasion: 95,
+			precision: 85,
+			power: 94,
+			evasion: 63,
 			damageType: "brute",
 			burnProtection: 10,
 			bruteProtection: 5
@@ -17,18 +17,18 @@ export default {
 				chance: 0.5,
 				itemTable: [
 					{
+						id: 'potionXenobiology',
+						weight: 10
+					},
+					{
+						id: 'foodEvasion1',
+						weight: 9
+					},
+					{
 						id: 'ticket3',
 						count: [0, 2],
 						weight: 1
 					},
-					{
-						id: 'gold',
-						weight: 1
-					},
-					{
-						id: 'titanium',
-						weight: 1
-					}
 				]
 			},
 			{
@@ -55,16 +55,16 @@ export default {
 				chance: 0.5,
 				itemTable: [
 					{
-						id: 'gold',
-						weight: 1
+						id: 'foot',
+						weight: 8
 					},
 					{
-						id: 'gold',
-						weight: 1
+						id: 'gunBallistic4',
+						weight: 3
 					},
 					{
-						id: 'titanium',
-						weight: 1
+						id: 'potionShitposting',
+						weight: 2
 					}
 				]
 			},
@@ -80,9 +80,9 @@ export default {
 		stats: {
 			maxHealth: 330,
 			attackSpeed: 1.9,
-			precision: 85,
-			power: 94,
-			evasion: 63,
+			precision: 86,
+			power: 91,
+			evasion: 95,
 			damageType: "brute",
 			burnProtection: 20,
 			bruteProtection: 5
@@ -93,14 +93,15 @@ export default {
 				itemTable: [
 					{
 						id: 'ammoBallistic4',
-						weight: 1
+						count:8,
+						weight: 10
 					},
 					{
-						id: 'gold',
-						weight: 1
+						id: 'q_foodEvasion1',
+						weight: 9
 					},
 					{
-						id: 'titanium',
+						id: 'pillSpacelube',
 						weight: 1
 					}
 				]
@@ -134,16 +135,21 @@ export default {
 				itemTable: [
 					{
 						id: 'bananaBlue',
-						weight: 1
+						weight: 3
 					},
 					{
 						id: 'mushroomRed',
-						weight: 1
+						weight: 2
 					},
 					{
 						id: 'plantSeed',
+						count:5,
+						weight: 2
+					},
+					{
+						id: 'burnJunk',
 						weight: 1
-					}
+					},
 				]
 			},
 			{

--- a/src/data/items/resourceTinkering.js
+++ b/src/data/items/resourceTinkering.js
@@ -6,7 +6,7 @@ export default {
 	// },
 	burnJunk: {
 		name: "Flammable Junk",
-		sellPrice: 200,
+		sellPrice: 189,
 		icon: require("@/assets/art/tinkering/burnjunk.png")
 	},
 }

--- a/src/data/items/slotChest.js
+++ b/src/data/items/slotChest.js
@@ -1,7 +1,7 @@
 const BRUTEARMOR = {
 	armorBrute1: {
 		name: "Cardborg Disguise",
-		sellPrice: 600,
+		sellPrice: 158,
 		icon: require("@/assets/art/combat/items/arm_b1.png"), overlay: require("@/assets/art/combat/items/arm_b1_overlay.png"),
 		stats: {
 		},
@@ -11,7 +11,7 @@ const BRUTEARMOR = {
 	},
 	armorBrute2: {
 		name: "Firefighting Suit",
-		sellPrice: 600,
+		sellPrice: 180,
 		icon: require("@/assets/art/combat/items/arm_b2.png"), overlay: require("@/assets/art/combat/items/arm_b2_overlay.png"),
 		stats: {
 			burnProtection: 2
@@ -22,7 +22,7 @@ const BRUTEARMOR = {
 	},
 	armorBrute3: {
 		name: "Personal Protection Vest PPV",
-		sellPrice: 600,
+		sellPrice: 202,
 		icon: require("@/assets/art/combat/items/arm_b3.png"), overlay: require("@/assets/art/combat/items/arm_b3_overlay.png"),
 		stats: {
 		},
@@ -32,7 +32,7 @@ const BRUTEARMOR = {
 	},
 	armorBrute4: {
 		name: "Reflective Protection Vest RPV",
-		sellPrice: 600,
+		sellPrice: 224,
 		icon: require("@/assets/art/combat/items/arm_b4.png"), overlay: require("@/assets/art/combat/items/arm_b4_overlay.png"),
 		stats: {
 		},
@@ -42,7 +42,7 @@ const BRUTEARMOR = {
 	},
 	armorBrute5: {
 		name: "Armored Biohazard Protection Suit",
-		sellPrice: 600,
+		sellPrice: 246,
 		icon: require("@/assets/art/combat/items/arm_b5.png"), overlay: require("@/assets/art/combat/items/arm_b5_overlay.png"),
 		stats: {
 		},
@@ -52,7 +52,7 @@ const BRUTEARMOR = {
 	},
 	armorBrute6: {
 		name: "Riot Suit",
-		sellPrice: 600,
+		sellPrice: 768,
 		icon: require("@/assets/art/combat/items/arm_b6.png"), overlay: require("@/assets/art/combat/items/arm_b6_overlay.png"),
 		stats: {
 		},
@@ -64,7 +64,7 @@ const BRUTEARMOR = {
 const BURNARMOR = {
 	armorBurn1: {
 		name: "EVA Suit",
-		sellPrice: 600,
+		sellPrice: 156,
 		icon: require("@/assets/art/combat/items/arm_s1.png"), overlay: require("@/assets/art/combat/items/arm_s1_overlay.png"),
 		stats: {
 		},
@@ -74,7 +74,7 @@ const BURNARMOR = {
 	},
 	armorBurn2: {
 		name: "Medical Rated Spacesuit",
-		sellPrice: 600,
+		sellPrice: 178,
 		icon: require("@/assets/art/combat/items/arm_s2.png"), overlay: require("@/assets/art/combat/items/arm_s2_overlay.png"),
 		stats: {
 		},
@@ -84,7 +84,7 @@ const BURNARMOR = {
 	},
 	armorBurn3: {
 		name: "Scientific Hardsuit",
-		sellPrice: 600,
+		sellPrice: 200,
 		icon: require("@/assets/art/combat/items/arm_s3.png"), overlay: require("@/assets/art/combat/items/arm_s3_overlay.png"),
 		stats: {
 		},
@@ -94,7 +94,7 @@ const BURNARMOR = {
 	},
 	armorBurn4: {
 		name: "Advanced Hardsuit",
-		sellPrice: 600,
+		sellPrice: 222,
 		icon: require("@/assets/art/combat/items/arm_s4.png"), overlay: require("@/assets/art/combat/items/arm_s4_overlay.png"),
 		stats: {
 		},
@@ -104,7 +104,7 @@ const BURNARMOR = {
 	},
 	armorBurn5: {
 		name: "Captains Hardsuit",
-		sellPrice: 600,
+		sellPrice: 244,
 		icon: require("@/assets/art/combat/items/arm_s5.png"), overlay: require("@/assets/art/combat/items/arm_s5_overlay.png"),
 		stats: {
 		},
@@ -114,7 +114,7 @@ const BURNARMOR = {
 	},
 	armorBurn6: {
 		name: "Syndicate Hardsuit",
-		sellPrice: 1200,
+		sellPrice: 766,
 		icon: require("@/assets/art/combat/items/arm_syndi.png"), overlay: require("@/assets/art/combat/items/arm_syndi_overlay.png"),
 		stats: {
 		},

--- a/src/data/tinkering.js
+++ b/src/data/tinkering.js
@@ -1,35 +1,35 @@
 const ACTIONS_RECYCLING = {
 	tinkerRecycleJ: {
-		time: 10,
+		time: 3,
 		actionName: "RECYCLE INTO",
 		item: "burnJunk",
 		icon: require("@/assets/art/tinkering/burnjunk.png"),
-		xp: 10,
+		xp: 2,
 		requiredLevel: 1,
 		requiredItems: {
-			junk: 2
+			junk: 1
 		}
 	},
 	tinkerRecycleS: {
-		time: 10,
+		time: 3,
 		item: "burnJunk",
 		actionName: "RECYCLE INTO",
 		icon: require("@/assets/art/tinkering/burnjunk.png"),
-		xp: 10,
+		xp: 2,
 		requiredLevel: 1,
 		requiredItems: {
-			spaceJunk: 2
+			spaceJunk: 1
 		}
 	},
 	tinkerRecycleA: {
-		time: 10,
+		time: 3,
 		item: "burnJunk",
 		actionName: "RECYCLE INTO",
 		icon: require("@/assets/art/tinkering/burnjunk.png"),
-		xp: 10,
+		xp: 2,
 		requiredLevel: 1,
 		requiredItems: {
-			armorJunk: 2
+			armorJunk: 1
 		}
 	},
 }


### PR DESCRIPTION
Changes (lower) sell prices on tinkering chests.

Nerfs? (reduces) the combat stats of the first two enemies
Lowers the requirements to create flammable junk as well as time and XP.

Improves some mid-late game combat drop tables. More work to come in the future still here.