### PR TITLE
Upgrades the healing and health components on ALL

### DIFF
--- a/src/data/items/foodBotany.js
+++ b/src/data/items/foodBotany.js
@@ -8,7 +8,7 @@ export default {
 		name: "Potato",
 		sellPrice: 5,
 		icon: require("@/assets/art/botany/PlantPotato.png"),
-		healAmount: 5,
+		healAmount: 10,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -20,7 +20,7 @@ export default {
 		name: "Tomato",
 		sellPrice: 5,
 		icon: require("@/assets/art/botany/PlantTomato.png"),
-		healAmount: 5,
+		healAmount: 10,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -32,7 +32,7 @@ export default {
 		name: "Banana",
 		sellPrice: 14,
 		icon: require("@/assets/art/botany/PlantBanana.png"),
-		healAmount: 5,
+		healAmount: 10,
 		stats: {
 			maxHealth: 0,
 			evasion: 5,
@@ -44,7 +44,7 @@ export default {
 		name: "Sunflower",
 		sellPrice: 14,
 		icon: require("@/assets/art/botany/PlantFlowersun.png"),
-		healAmount: 5,
+		healAmount: 10,
 		stats: {
 			maxHealth: 0,
 			evasion: 5,
@@ -56,7 +56,7 @@ export default {
 		name: "Glowshroom",
 		sellPrice: 25,
 		icon: require("@/assets/art/botany/PlantShroomglow.png"),
-		healAmount: 5,
+		healAmount: 10,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -68,7 +68,7 @@ export default {
 		name: "Hot Pepper",
 		sellPrice: 25,
 		icon: require("@/assets/art/botany/PlantPepperhot.png"),
-		healAmount: 5,
+		healAmount: 10,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -80,7 +80,7 @@ export default {
 		name: "Potato Battery",
 		sellPrice: 37,
 		icon: require("@/assets/art/botany/PlantPotatobattery.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -92,7 +92,7 @@ export default {
 		name: "Blue Tomato",
 		sellPrice: 37,
 		icon: require("@/assets/art/botany/PlantTomatoblue.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -104,7 +104,7 @@ export default {
 		name: "...",
 		sellPrice: 45,
 		icon: require("@/assets/art/botany/PlantBananamime.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 10,
@@ -116,7 +116,7 @@ export default {
 		name: "Moonflower",
 		sellPrice: 45,
 		icon: require("@/assets/art/botany/PlantFlowermoon.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 10,
@@ -128,7 +128,7 @@ export default {
 		name: "Glowcap",
 		sellPrice: 52,
 		icon: require("@/assets/art/botany/PlantShroomred.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -140,7 +140,7 @@ export default {
 		name: "Ice Pepper",
 		sellPrice: 52,
 		icon: require("@/assets/art/botany/PlantPeppercold.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -152,7 +152,7 @@ export default {
 		name: "Orange",
 		sellPrice: 61,
 		icon: require("@/assets/art/botany/PlantOrange.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 5,
 			evasion: -5,
@@ -164,7 +164,7 @@ export default {
 		name: "Bluespace Tomato",
 		sellPrice: 61,
 		icon: require("@/assets/art/botany/PlantTomatobluespace_anim.gif"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 5,
 			evasion: 0,
@@ -176,7 +176,7 @@ export default {
 		name: "Blue Banana",
 		sellPrice: 27,
 		icon: require("@/assets/art/botany/PlantBananablue.png"),
-		healAmount: 66,
+		healAmount: 30,
 		stats: {
 			maxHealth: 5,
 			evasion: 10,
@@ -188,7 +188,7 @@ export default {
 		name: "Novaflower",
 		sellPrice: 66,
 		icon: require("@/assets/art/botany/PlantFlowernova.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 5,
 			evasion: 10,
@@ -200,7 +200,7 @@ export default {
 		name: "Shadowshroom",
 		sellPrice: 71,
 		icon: require("@/assets/art/botany/PlantShroomshadow.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 5,
 			evasion: -5,
@@ -212,7 +212,7 @@ export default {
 		name: "Ghost Pepper",
 		sellPrice: 71,
 		icon: require("@/assets/art/botany/PlantPepperghost.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 5,
 			evasion: 0,
@@ -224,7 +224,7 @@ export default {
 		name: "Multidimensional Orange",
 		sellPrice: 83,
 		icon: require("@/assets/art/botany/PlantOrange3d_anim.gif"),
-		healAmount: 20,
+		healAmount: 40,
 		stats: {
 			maxHealth: -5,
 			evasion: 5,

--- a/src/data/items/foodCooking.js
+++ b/src/data/items/foodCooking.js
@@ -5,7 +5,7 @@ let FOOD = {
 		name: "Human Meat",
 		sellPrice: 10,
 		icon: require("@/assets/art/cooking/meatHuman.png"),
-		healAmount: 10,
+		healAmount: 15,
 		stats: {
 			maxHealth: 2,
 			evasion: -1,
@@ -17,7 +17,7 @@ let FOOD = {
 		name: "Alien Meat",
 		sellPrice: 10,
 		icon: require("@/assets/art/cooking/meatAlien.png"),
-		healAmount: 10,
+		healAmount: 15,
 		stats: {
 			maxHealth: 2,
 			evasion: 2,
@@ -29,7 +29,7 @@ let FOOD = {
 		name: "Animal Meat",
 		sellPrice: 10,
 		icon: require("@/assets/art/cooking/meatAnimal.png"),
-		healAmount: 10,
+		healAmount: 15,
 		stats: {
 			maxHealth: 2,
 			evasion: -1,
@@ -41,7 +41,7 @@ let FOOD = {
 		name: "Pasta",
 		sellPrice: 8,
 		icon: require("@/assets/art/cooking/pasta1.png"),
-		healAmount: 3,
+		healAmount: 6,
 		stats: {
 			maxHealth: -3,
 			evasion: 0,
@@ -53,7 +53,7 @@ let FOOD = {
 		name: "Double Pasta",
 		sellPrice: 45,
 		icon: require("@/assets/art/cooking/pasta2.png"),
-		healAmount: 6,
+		healAmount: 12,
 		stats: {
 			maxHealth: -6,
 			evasion: 1,
@@ -65,7 +65,7 @@ let FOOD = {
 		name: "Triple Pasta",
 		sellPrice: 113,
 		icon: require("@/assets/art/cooking/pasta3.png"),
-		healAmount: 9,
+		healAmount: 18,
 		stats: {
 			maxHealth: -9,
 			evasion: 2,
@@ -77,7 +77,7 @@ let FOOD = {
 		name: "Pasta Tower",
 		sellPrice: 211,
 		icon: require("@/assets/art/cooking/pasta4.png"),
-		healAmount: 12,
+		healAmount: 24,
 		stats: {
 			maxHealth: -12,
 			evasion: 3,
@@ -89,7 +89,7 @@ let FOOD = {
 		name: "InSPIREd Pasta",
 		sellPrice: 338,
 		icon: require("@/assets/art/cooking/pasta5.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: -15,
 			evasion: 4,
@@ -101,7 +101,7 @@ let FOOD = {
 		name: "Babel Pasta",
 		sellPrice: 496,
 		icon: require("@/assets/art/cooking/pasta6.png"),
-		healAmount: 18,
+		healAmount: 36,
 		stats: {
 			maxHealth: -18,
 			evasion: 5,
@@ -113,7 +113,7 @@ let FOOD = {
 		name: "Hot Potato Stew",
 		sellPrice: 20,
 		icon: require("@/assets/art/cooking/stew1.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -125,7 +125,7 @@ let FOOD = {
 		name: "Tingle Soup",
 		sellPrice: 102,
 		icon: require("@/assets/art/cooking/stew2.png"),
-		healAmount: 30,
+		healAmount: 45,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -137,7 +137,7 @@ let FOOD = {
 		name: "Dad's Soup",
 		sellPrice: 171,
 		icon: require("@/assets/art/cooking/stew3.png"),
-		healAmount: 45,
+		healAmount: 60,
 		stats: {
 			maxHealth: 10,
 			evasion: -5,
@@ -149,7 +149,7 @@ let FOOD = {
 		name: "Donkpocket",
 		sellPrice: 26,
 		icon: require("@/assets/art/cooking/donk1.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -161,7 +161,7 @@ let FOOD = {
 		name: "Berrypocket",
 		sellPrice: 108,
 		icon: require("@/assets/art/cooking/donk2.png"),
-		healAmount: 30,
+		healAmount: 45,
 		stats: {
 			maxHealth: 0,
 			evasion: -5,
@@ -173,7 +173,7 @@ let FOOD = {
 		name: "Dankpocket",
 		sellPrice: 177,
 		icon: require("@/assets/art/cooking/donk3.png"),
-		healAmount: 45,
+		healAmount: 60,
 		stats: {
 			maxHealth: 10,
 			evasion: -5,
@@ -185,7 +185,7 @@ let FOOD = {
 		name: "Creampie",
 		sellPrice: 31,
 		icon: require("@/assets/art/cooking/pie1.png"),
-		healAmount: 15,
+		healAmount: 30,
 		stats: {
 			maxHealth: 0,
 			evasion: 10,
@@ -197,7 +197,7 @@ let FOOD = {
 		name: "Moonpie",
 		sellPrice: 115,
 		icon: require("@/assets/art/cooking/pie2.png"),
-		healAmount: 30,
+		healAmount: 45,
 		stats: {
 			maxHealth: 0,
 			evasion: 20,
@@ -221,7 +221,7 @@ let FOOD = {
 		name: "Spicy Burger",
 		sellPrice: 48,
 		icon: require("@/assets/art/cooking/burger1.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -233,7 +233,7 @@ let FOOD = {
 		name: "Slippery Burger",
 		sellPrice: 122,
 		icon: require("@/assets/art/cooking/burger2.png"),
-		healAmount: 20,
+		healAmount: 40,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -245,7 +245,7 @@ let FOOD = {
 		name: "Blue Burger",
 		sellPrice: 160,
 		icon: require("@/assets/art/cooking/burger3.png"),
-		healAmount: 30,
+		healAmount: 50,
 		stats: {
 			maxHealth: 10,
 			evasion: 0,
@@ -257,7 +257,7 @@ let FOOD = {
 		name: "Ghost Burger",
 		sellPrice: 185,
 		icon: require("@/assets/art/cooking/burger4_anim.gif"),
-		healAmount: 30,
+		healAmount: 50,
 		stats: {
 			maxHealth: 10,
 			evasion: 0,
@@ -269,7 +269,7 @@ let FOOD = {
 		name: "Pizza",
 		sellPrice: 63,
 		icon: require("@/assets/art/cooking/animal1.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -281,7 +281,7 @@ let FOOD = {
 		name: "Moon Pizza",
 		sellPrice: 111,
 		icon: require("@/assets/art/cooking/animal2.png"),
-		healAmount: 20,
+		healAmount: 40,
 		stats: {
 			maxHealth: 0,
 			evasion: 0,
@@ -293,7 +293,7 @@ let FOOD = {
 		name: "Bluespace Pizza",
 		sellPrice: 162,
 		icon: require("@/assets/art/cooking/animal3.png"),
-		healAmount: 30,
+		healAmount: 50,
 		stats: {
 			maxHealth: 10,
 			evasion: 0,
@@ -305,7 +305,7 @@ let FOOD = {
 		name: "Nova Pizza",
 		sellPrice: 187,
 		icon: require("@/assets/art/cooking/animal4.png"),
-		healAmount: 30,
+		healAmount: 50,
 		stats: {
 			maxHealth: 10,
 			evasion: 0,
@@ -317,7 +317,7 @@ let FOOD = {
 		name: "Fesh 'Shishi'",
 		sellPrice: 69,
 		icon: require("@/assets/art/cooking/Alien1.png"),
-		healAmount: 10,
+		healAmount: 20,
 		stats: {
 			maxHealth: 0,
 			evasion: 5,
@@ -329,7 +329,7 @@ let FOOD = {
 		name: "Finger Food",
 		sellPrice: 122,
 		icon: require("@/assets/art/cooking/Alien2.png"),
-		healAmount: 20,
+		healAmount: 40,
 		stats: {
 			maxHealth: 0,
 			evasion: 10,
@@ -341,7 +341,7 @@ let FOOD = {
 		name: "Fush n Chips",
 		sellPrice: 168,
 		icon: require("@/assets/art/cooking/Alien3.png"),
-		healAmount: 30,
+		healAmount: 50,
 		stats: {
 			maxHealth: 5,
 			evasion: 10,
@@ -353,7 +353,7 @@ let FOOD = {
 		name: "Fried Friend",
 		sellPrice: 197,
 		icon: require("@/assets/art/cooking/Alien4.png"),
-		healAmount: 30,
+		healAmount: 50,
 		stats: {
 			maxHealth: 10,
 			evasion: 10,

--- a/src/data/items/foodOther.js
+++ b/src/data/items/foodOther.js
@@ -9,13 +9,7 @@ export default {
 		name: "Human Foot",
 		sellPrice: -5,
 		icon: require("@/assets/art/cooking/meatFoot.png"),
-		healAmount: 10
-	},
-	spaghetti: {
-		name: "Spaghetti",
-		sellPrice: 100,
-		icon: require('@/assets/art/shop/items/spaghetti.png'),
-		healAmount: 30
+		healAmount: 120
 	},
 	cactus: {
 		name: "Exotic Cactus",

--- a/src/data/items/slotChest.js
+++ b/src/data/items/slotChest.js
@@ -291,7 +291,7 @@ Object.values(BRUTEARMOR).forEach(brutearmor => {
 	brutearmor.equipmentSlot = "chest";
 	let bruteConstant = Math.max(10, brutearmor.requires.evasion);
 
-	brutearmor.stats.maxHealth = Math.trunc(bruteConstant * 2.5) + 10;
+	brutearmor.stats.maxHealth = Math.trunc(bruteConstant * 4) + 10;
 	brutearmor.stats.power = Math.ceil(bruteConstant * .05);
 	brutearmor.stats.evasion = Math.ceil(bruteConstant * 0.45);
 	brutearmor.stats.bruteProtection = Math.round(bruteConstant * .2) + 2;
@@ -301,7 +301,7 @@ Object.values(BURNARMOR).forEach(burnarmor => {
 	burnarmor.equipmentSlot = "chest";
 	let burnConstant = Math.max(5, burnarmor.requires.evasion);
 
-	burnarmor.stats.maxHealth = Math.trunc(burnConstant * 2.5) + 10;
+	burnarmor.stats.maxHealth = Math.trunc(burnConstant * 4) + 10;
 	burnarmor.stats.precision = Math.ceil(burnConstant * .05);
 	burnarmor.stats.evasion = Math.ceil(burnConstant * 0.4);
 	burnarmor.stats.burnProtection = Math.round(burnConstant * .3) + 3;
@@ -315,7 +315,7 @@ Object.values(MECHS).forEach(mech => {
 	mech.requires.evasion = Math.trunc(mech.requires.fabrication / 2);
 	if (Object.values(mech.stats).length > 0) return;
 	mech.stats.moveTime = 3;
-	mech.stats.maxHealth = (mech.requires.fabrication * 3.5) + 20;
+	mech.stats.maxHealth = (mech.requires.fabrication * 5) + 20;
 	mech.stats.precision = Math.ceil(mech.requires.fabrication * .2);
 	mech.stats.power = Math.ceil(mech.requires.fabrication * .2);
 	mech.stats.evasion = Math.trunc(mech.requires.fabrication * .1);

--- a/src/data/items/slotCompanion.js
+++ b/src/data/items/slotCompanion.js
@@ -219,7 +219,7 @@ Object.values(SLIMES).forEach((slime, index) => {
 
 	if (mod == 0) {
 		slime.stats = {
-			maxHealth: (slime.tier) * 10,
+			maxHealth: (slime.tier) * 15,
 			burnProtection: (slime.tier - 1) * 4
 		}
 	}

--- a/src/data/items/slotFace.js
+++ b/src/data/items/slotFace.js
@@ -6,11 +6,11 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_meson_overlay.png"),
 		stats: {
-			maxHealth: 2,
-			evasion: 2,
-			protection: -5,
-			precision: 2,
-			power: 2,
+			maxHealth: 20,
+			evasion: 3,
+			protection: -6,
+			precision: 3,
+			power: 3,
 		},
 		requires: {
 			evasion: 10,
@@ -23,10 +23,10 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_healthhud_overlay.png"),
 		stats: {
-			maxHealth: 4,
+			maxHealth: 20,
 			evasion: 0,
 			protection: 0,
-			precision: 2,
+			precision: 3,
 			power: 0,
 		},
 		requires: {
@@ -40,9 +40,9 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_secglass_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 0,
-			protection: 5,
+			protection: 3,
 			precision: 0,
 			power: 0,
 		},
@@ -57,10 +57,10 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_science_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 0,
-			protection: -5,
-			precision: 4,
+			protection: -4,
+			precision: 7,
 			power: 0,
 		},
 		requires: {
@@ -74,14 +74,14 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_tiki_overlay.png"),
 		stats: {
-			maxHealth: 2,
+			maxHealth: 30,
 			evasion: 2,
 			protection: 0,
 			precision: 0,
 			power: 2,
 		},
 		requires: {
-			evasion: 3,
+			evasion: 30,
 		}
 	},
 	faceWrestle: {
@@ -91,14 +91,14 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_wrestle_overlay.png"),
 		stats: {
-			maxHealth: 2,
+			maxHealth: 30,
 			evasion: 2,
 			protection: 0,
 			precision: 2,
 			power: 0,
 		},
 		requires: {
-			evasion: 3,
+			evasion: 30,
 		}
 	},
 	faceGas: {
@@ -108,14 +108,14 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_gas_overlay.png"),
 		stats: {
-			maxHealth: 2,
+			maxHealth: 30,
 			evasion: 0,
 			protection: 0,
 			precision: 2,
 			power: 2,
 		},
 		requires: {
-			evasion: 3,
+			evasion: 30,
 		}
 	},
 	faceFox: {
@@ -125,7 +125,7 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_fox_overlay.png"),
 		stats: {
-			maxHealth: 4,
+			maxHealth: 30,
 			evasion: 0,
 			protection: 0,
 			precision: 4,
@@ -142,7 +142,7 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_sec_overlay.png"),
 		stats: {
-			maxHealth: 4,
+			maxHealth: 30,
 			evasion: 0,
 			protection: 0,
 			precision: 0,
@@ -159,7 +159,7 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_syndicate_overlay_anim.gif"),
 		stats: {
-			maxHealth: 4,
+			maxHealth: 30,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -176,7 +176,7 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_mime_overlay.png"),
 		stats: {
-			maxHealth: -10,
+			maxHealth: -130,
 			evasion: 10,
 			protection: -10,
 			precision: 10,
@@ -193,7 +193,7 @@ export default {
 		equipmentSlot: "face",
 		overlay: require("@/assets/art/combat/items/face_mime_overlay.png"),
 		stats: {
-			maxHealth: 15,
+			maxHealth: 170,
 			evasion: 0,
 			protection: 0,
 			precision: -10,

--- a/src/data/items/slotHead.js
+++ b/src/data/items/slotHead.js
@@ -6,7 +6,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/headset_1_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 40,
 			evasion: 3,
 			protection: 0,
 			precision: 1,
@@ -22,7 +22,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/headset_2_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 40,
 			evasion: 3,
 			protection: 1,
 			precision: 0,
@@ -38,7 +38,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/headset_3_overlay.png"),
 		stats: {
-			maxHealth: 6,
+			maxHealth: 50,
 			evasion: 3,
 			protection: 0,
 			precision: 0,
@@ -54,7 +54,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/headset_4_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 40,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -70,7 +70,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/headset_5_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 40,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -87,7 +87,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_h1_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			evasion: 4,
 			protection: 0,
 			precision: 2,
@@ -103,7 +103,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_h2_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			evasion: 4,
 			protection: 2,
 			precision: 0,
@@ -119,7 +119,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_h3_overlay.png"),
 		stats: {
-			maxHealth: 8,
+			maxHealth: 80,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -135,7 +135,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_h4_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			evasion: 6,
 			protection: 0,
 			precision: 0,
@@ -151,7 +151,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_h5_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -168,7 +168,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_r1_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 90,
 			evasion: 6,
 			protection: 0,
 			precision: 2,
@@ -184,7 +184,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_r2_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 90,
 			evasion: 6,
 			protection: 2,
 			precision: 0,
@@ -200,7 +200,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_r3_overlay.png"),
 		stats: {
-			maxHealth: 8,
+			maxHealth: 110,
 			evasion: 6,
 			protection: 0,
 			precision: 0,
@@ -216,7 +216,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_r4_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 90,
 			evasion: 8,
 			protection: 0,
 			precision: 0,
@@ -232,7 +232,7 @@ export default {
 		equipmentSlot: "head",
 		overlay: require("@/assets/art/combat/items/head/head_r5_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 90,
 			evasion: 6,
 			protection: 0,
 			precision: 0,

--- a/src/data/items/slotJumpsuit.js
+++ b/src/data/items/slotJumpsuit.js
@@ -6,7 +6,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_medical.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_medical_overlay.png"),
 		stats: {
-			maxHealth: 20
+			maxHealth: 130
 		},
 		requires: {
 			evasion: 5
@@ -19,7 +19,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_mining.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_mining_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			power: 5,
 			evasion: 3
 		},
@@ -38,7 +38,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_engi.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_engi_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			precision: 5,
 			evasion: 3
 		},
@@ -57,7 +57,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_robotics.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_robotics_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			precision: 5,
 			evasion: 3
 		},
@@ -76,7 +76,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_grey.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_grey_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			power: 5,
 			evasion: 3
 		},
@@ -95,7 +95,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_janitor.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_janitor_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			precision: 5,
 			evasion: 3
 		},
@@ -114,7 +114,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_botany.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_botany_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			power: 5,
 			evasion: 3
 		},
@@ -133,7 +133,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_chef.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_chef_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			precision: 5,
 			evasion: 3
 		},
@@ -152,7 +152,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_chemistry.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_chemistry_overlay.png"),
 		stats: {
-			maxHealth: 10,
+			maxHealth: 50,
 			power: 5,
 			evasion: 3
 		},
@@ -171,7 +171,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_science.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_science_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 50,
 			evasion: 3,
 			command:5
 		},
@@ -190,7 +190,7 @@ export default {
 		icon: require("@/assets/art/combat/items/jumpsuit_valid.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_valid_overlay.png"),
 		stats: {
-			maxHealth: 5,
+			maxHealth: 60,
 			precision: 2,
 			power: 2,
 			evasion: 3

--- a/src/data/items/slotLimb.js
+++ b/src/data/items/slotLimb.js
@@ -6,7 +6,7 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/glove_yellow_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: -4,
 			power: 7,
 			evasion: 7,
@@ -23,7 +23,7 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/glove_boxing_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: 7,
 			power: -4,
 			evasion: 7,
@@ -40,7 +40,7 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/glove_fightgloves_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: 7,
 			power: 7,
 			evasion: -4,
@@ -57,11 +57,12 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/glove_captain_overlay.png"),
 		stats: {
-			maxHealth: 10,
+			maxHealth: 60,
 			precision: 0,
 			power: 0,
 			evasion: 0,
-			protection: 2,
+			protection: 5,
+			command: 5
 		},
 		requires: {
 			evasion: 15,
@@ -74,11 +75,11 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/glove_ninja_overlay.png"),
 		stats: {
-			maxHealth: 30,
-			precision: 0,
-			power: 0,
-			evasion: 0,
-			protection: -4,
+			maxHealth: 60,
+			precision: 4,
+			power: 4,
+			evasion: 4,
+			command: -5,
 		},
 		requires: {
 			evasion: 15,
@@ -91,7 +92,7 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/shoe_black_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: 5,
 			power: 0,
 			evasion: 5,
@@ -108,7 +109,7 @@ export default {
 		equipmentSlot: "climb",
 		overlay: require("@/assets/art/combat/items/shoe_magboots_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: 5,
 			power: 5,
 			evasion: 0,
@@ -125,7 +126,7 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/shoe_clown_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: 0,
 			power: 5,
 			evasion: 5,
@@ -142,11 +143,11 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/shoe_jackboots_overlay.png"),
 		stats: {
-			maxHealth: 0,
+			maxHealth: 60,
 			precision: 0,
 			power: 0,
 			evasion: 0,
-			protection: 4,
+			protection: 5,
 		},
 		requires: {
 			evasion: 10,
@@ -159,7 +160,7 @@ export default {
 		equipmentSlot: "limb",
 		overlay: require("@/assets/art/combat/items/shoe_advmag_overlay.png"),
 		stats: {
-			maxHealth: 3,
+			maxHealth: 60,
 			precision: 3,
 			power: 3,
 			evasion: 3,

--- a/src/data/items/slotNeck.js
+++ b/src/data/items/slotNeck.js
@@ -8,7 +8,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/cloakmining_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -27,10 +27,10 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/engcloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
 			protection: 0,
-			precision: 2,
+			precision: 1,
 			power: 0,
 		},
 		requires: {
@@ -46,7 +46,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/hoscloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
 			protection: 0,
 			precision: 1,
@@ -65,7 +65,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/capcloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 5,
 			protection: 0,
 			precision: 0,
@@ -84,9 +84,9 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/tinkeringcloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
-			bruteProtection: 4,
+			bruteProtection: 2,
 			precision: 0,
 			power: 0,
 		},
@@ -101,7 +101,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/hopcloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 4,
+			maxHealth: 30,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -118,9 +118,9 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/cookingcloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
-			burnProtection: 4,
+			burnProtection: 2,
 			precision: 0,
 			power: 0,
 		},
@@ -137,7 +137,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/scicloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -157,7 +157,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/cmocloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 0,
+			maxHealth: 20,
 			evasion: 4,
 			protection: 0,
 			precision: 0,
@@ -177,7 +177,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/cloak/shitcloak_overlay.png"),
 		equipmentSlot: "neck",
 		stats: {
-			maxHealth: 5,
+			maxHealth: 30,
 			evasion: 3,
 			precision: 2,
 			power: 2,


### PR DESCRIPTION
Botany food now heals for DOUBLE
Cooked foods are now approximately double

Items that used some of their power budget have been buffed. 1 point = 10 health.

All values below are at max level
BUFFS Chest max health bonus up to 210 (nonmechs)
BUFFS Head max health bonus up to 90
BUFFS Limb max health bonus up to 60
BUFFS Jumpsuit max health bonus up to 50
BUFFS Neck max health bonus up to 20
BUFFS Face max health bonus up to 30

BUFFS Xenobiology health bonuses (max remained the same but more provide it)