### PR TITLE
Removes duplicate reward for chemistry greytiding.

### DIFF
--- a/src/data/graytiding.js
+++ b/src/data/graytiding.js
@@ -230,7 +230,7 @@ const ACTIONS = {
 						count: [0, 5],
 						weight: 10
 					},{
-						id: "oxygen",
+						id: "water",
 						count: [0, 5],
 						weight: 10
 					},{


### PR DESCRIPTION
Chemistry greytiding had two oxygen rewards, and no water reward.

This removes the duplicate and adds water, so all bases are a potential reward.