### PR TITLE
Lots of small changes, Income Upgrades Bosses

### DIFF
--- a/src/components/Content/Combat/StatsPanel.vue
+++ b/src/components/Content/Combat/StatsPanel.vue
@@ -2,7 +2,7 @@
   <div class="d-flex flex-column align-items-center">
     <stat-panel-item
       name="Max Health"
-      description="Increases total health pool"
+      description="Increases total health pool and regeneration"
       :icon="require('@/assets/art/combat/health.gif')"
       :value="fixedStats.maxHealth"
     />

--- a/src/components/Content/ContentCombatJobInfo.vue
+++ b/src/components/Content/ContentCombatJobInfo.vue
@@ -107,7 +107,7 @@
       <li>
         <span>
           <img class="mx--2" :src="require('@/assets/art/combat/black_shoes.png')" />
-          <b>Evasion</b> increases your chance to dodge enemy attacks.
+          <b>Evasion</b> increases your chance to evade enemy attacks.
         </span>
       </li>
       <li>

--- a/src/components/Content/ContentTinkering.vue
+++ b/src/components/Content/ContentTinkering.vue
@@ -140,7 +140,7 @@
               class="mx--0"
               :src="require('@/assets/art/combat/black_shoes.png')"
             />
-            <b>Dodge</b> a lot more effectively. It alssso won't ssslow you down as you
+            <b>Evade</b> a lot more effectively. It alssso won't ssslow you down as you
             <img
               class="mx--0"
               :src="require('@/assets/art/combat/evasion.png')"

--- a/src/data/chemistry.js
+++ b/src/data/chemistry.js
@@ -165,7 +165,7 @@ const PILLS = {
 	synthPillCommand: {
 		items: {
 			id: "pillHappy",
-			count: PILL_COUNT*1.5
+			count: PILL_COUNT*1.25
 		},
 		sellPrice: 50,
 		icon: require("@/assets/art/combat/items/pill5.png"),

--- a/src/data/enemies/boss1-security.js
+++ b/src/data/enemies/boss1-security.js
@@ -17,6 +17,11 @@ const BOSSES = {
 				chance: 1,
 				itemTable: [
 					{
+						chance: 1,
+						item: "money",
+						count: [0-5000]
+					},
+					{
 						id: 'boss1Parts',
 						count: [6, 10],
 						weight: 8
@@ -29,9 +34,14 @@ const BOSSES = {
 				]
 			},
 			{
-				chance: 1,
-				item: "foodMeatH"
-			}
+			chance: 1,
+			itemTable: [
+				{
+					id: 'foodMeatH',
+					weight: 1,
+					count: 10
+				},
+			]}
 		]
 	},
 	sec2: {
@@ -50,6 +60,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-5000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'boss1Parts',
@@ -65,8 +80,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatH"
-			}
+				itemTable: [
+					{
+						id: 'foodMeatH',
+						weight: 1,
+						count: 10
+					},
+				]}
 		]
 	},
 	sec3: {
@@ -82,6 +102,11 @@ const BOSSES = {
 			damageType: "brute",
 		},
 		itemTables: [
+			{
+				chance: 1,
+				item: "money",
+				count: [0-5000]
+			},
 			{
 				chance: 1,
 				itemTable: [
@@ -102,7 +127,8 @@ const BOSSES = {
 				itemTable: [
 					{
 						id: 'foodMeatZ',
-						weight: 1
+						weight: 1,
+						count: 10
 					},
 				]
 			}
@@ -138,8 +164,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatH"
-			}
+				itemTable: [
+					{
+						id: 'foodMeatH',
+						weight: 1,
+						count: 10
+					},
+				]}
 		]
 	},
 }

--- a/src/data/enemies/boss2-lavaland.js
+++ b/src/data/enemies/boss2-lavaland.js
@@ -32,8 +32,9 @@ const BOSSES = {
 				chance: 1,
 				itemTable: [
 					{
-						id: 'foodMeatH',
-						weight: 1
+						id: 'foodMeatA',
+						weight: 1,
+						count: 10
 					},
 				]
 			}
@@ -55,6 +56,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-10000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'exoticParts',
@@ -72,8 +78,9 @@ const BOSSES = {
 				chance: 1,
 				itemTable: [
 					{
-						id: 'foodMeatZ',
-						weight: 1
+						id: 'foodMeatA',
+						weight: 1,
+						count: 10
 					},
 				]
 			}
@@ -95,6 +102,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-10000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'exoticParts',
@@ -110,7 +122,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "uranium"
+				itemTable: [
+					{
+						id: 'foodMeatH',
+						weight: 1,
+						count: 10
+					},
+				]
 			}
 		]
 	},
@@ -130,6 +148,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-10000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'exoticParts',
@@ -145,7 +168,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatZ"
+				itemTable: [
+					{
+						id: 'foodMeatA',
+						weight: 1,
+						count: 10
+					},
+				]
 			}
 		]
 	},

--- a/src/data/enemies/boss3-antag.js
+++ b/src/data/enemies/boss3-antag.js
@@ -15,6 +15,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-40000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'telecrystal',
@@ -30,7 +35,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatH"
+				itemTable: [
+					{
+						id: 'foodMeatZ',
+						weight: 1,
+						count: 25
+					},
+				]
 			}
 		]
 	},
@@ -50,6 +61,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-40000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'telecrystal',
@@ -65,7 +81,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatH"
+				itemTable: [
+					{
+						id: 'foodMeatA',
+						weight: 1,
+						count: 25
+					},
+				]
 			}
 		]
 	},
@@ -84,6 +106,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-40000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'telecrystal',
@@ -99,7 +126,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatA"
+				itemTable: [
+					{
+						id: 'foodMeatH',
+						weight: 1,
+						count: 25
+					},
+				]
 			}
 		]
 	},
@@ -118,6 +151,11 @@ const BOSSES = {
 		itemTables: [
 			{
 				chance: 1,
+				item: "money",
+				count: [0-50000]
+			},
+			{
+				chance: 1,
 				itemTable: [
 					{
 						id: 'telecrystal',
@@ -133,7 +171,13 @@ const BOSSES = {
 			},
 			{
 				chance: 1,
-				item: "foodMeatA"
+				itemTable: [
+					{
+						id: 'foodMeatA',
+						weight: 1,
+						count: 25
+					},
+				]
 			}
 		]
 	},

--- a/src/data/engineering.js
+++ b/src/data/engineering.js
@@ -230,7 +230,7 @@ const ILL_ADVISED_ACTIONS = {
 		name: "Stored Power",
 		items: {
 			id: "money",
-			count: 50
+			count: [200, 350]
 		},
 		icon: require("@/assets/art/engineering/smes_anim.gif"),
 		xp: 15,

--- a/src/data/items/foodBotany.js
+++ b/src/data/items/foodBotany.js
@@ -78,7 +78,7 @@ export default {
 	},
 	potatoBattery: {
 		name: "Potato Battery",
-		sellPrice: 37,
+		sellPrice: 35,
 		icon: require("@/assets/art/botany/PlantPotatobattery.png"),
 		healAmount: 20,
 		stats: {
@@ -90,7 +90,7 @@ export default {
 	},
 	tomatoBlue: {
 		name: "Blue Tomato",
-		sellPrice: 37,
+		sellPrice: 35,
 		icon: require("@/assets/art/botany/PlantTomatoblue.png"),
 		healAmount: 20,
 		stats: {
@@ -102,7 +102,7 @@ export default {
 	},
 	bananaMime: {
 		name: "...",
-		sellPrice: 45,
+		sellPrice: 42,
 		icon: require("@/assets/art/botany/PlantBananamime.png"),
 		healAmount: 20,
 		stats: {
@@ -114,7 +114,7 @@ export default {
 	},
 	flowerMoon: {
 		name: "Moonflower",
-		sellPrice: 45,
+		sellPrice: 42,
 		icon: require("@/assets/art/botany/PlantFlowermoon.png"),
 		healAmount: 20,
 		stats: {
@@ -126,7 +126,7 @@ export default {
 	},
 	mushroomRed: {
 		name: "Glowcap",
-		sellPrice: 52,
+		sellPrice: 48,
 		icon: require("@/assets/art/botany/PlantShroomred.png"),
 		healAmount: 20,
 		stats: {
@@ -138,7 +138,7 @@ export default {
 	},
 	peppercold: {
 		name: "Ice Pepper",
-		sellPrice: 52,
+		sellPrice: 48,
 		icon: require("@/assets/art/botany/PlantPeppercold.png"),
 		healAmount: 20,
 		stats: {
@@ -150,11 +150,11 @@ export default {
 	},
 	orange: {
 		name: "Orange",
-		sellPrice: 61,
+		sellPrice: 49,
 		icon: require("@/assets/art/botany/PlantOrange.png"),
 		healAmount: 30,
 		stats: {
-			maxHealth: 5,
+			maxHealth: 0,
 			evasion: -5,
 			precision: 0,
 			power: 10,
@@ -162,11 +162,11 @@ export default {
 	},
 	tomatoBluespace: {
 		name: "Bluespace Tomato",
-		sellPrice: 61,
+		sellPrice: 49,
 		icon: require("@/assets/art/botany/PlantTomatobluespace_anim.gif"),
 		healAmount: 30,
 		stats: {
-			maxHealth: 5,
+			maxHealth: 0,
 			evasion: 0,
 			precision: 10,
 			power: -5,
@@ -174,11 +174,11 @@ export default {
 	},
 	bananaBlue: {
 		name: "Blue Banana",
-		sellPrice: 27,
+		sellPrice: 53,
 		icon: require("@/assets/art/botany/PlantBananablue.png"),
 		healAmount: 30,
 		stats: {
-			maxHealth: 5,
+			maxHealth: 0,
 			evasion: 10,
 			precision: -5,
 			power: 0,
@@ -186,11 +186,11 @@ export default {
 	},
 	flowerNova: {
 		name: "Novaflower",
-		sellPrice: 66,
+		sellPrice: 53,
 		icon: require("@/assets/art/botany/PlantFlowernova.png"),
 		healAmount: 30,
 		stats: {
-			maxHealth: 5,
+			maxHealth: 0,
 			evasion: 10,
 			precision: 0,
 			power: -5,
@@ -198,11 +198,11 @@ export default {
 	},
 	mushroomShadow: {
 		name: "Shadowshroom",
-		sellPrice: 71,
+		sellPrice: 57,
 		icon: require("@/assets/art/botany/PlantShroomshadow.png"),
 		healAmount: 30,
 		stats: {
-			maxHealth: 5,
+			maxHealth: 0,
 			evasion: -5,
 			precision: 10,
 			power: 0,
@@ -210,11 +210,11 @@ export default {
 	},
 	pepperGhost: {
 		name: "Ghost Pepper",
-		sellPrice: 71,
+		sellPrice: 57,
 		icon: require("@/assets/art/botany/PlantPepperghost.png"),
 		healAmount: 30,
 		stats: {
-			maxHealth: 5,
+			maxHealth: 0,
 			evasion: 0,
 			precision: -5,
 			power: 10,
@@ -222,11 +222,12 @@ export default {
 	},
 	orange3d: {
 		name: "Multidimensional Orange",
-		sellPrice: 83,
+		description: 'Looking at this makes your head hurt',
+		sellPrice: 61,
 		icon: require("@/assets/art/botany/PlantOrange3d_anim.gif"),
 		healAmount: 40,
 		stats: {
-			maxHealth: -5,
+			maxHealth: -50,
 			evasion: 5,
 			precision: 5,
 			power: 5,

--- a/src/data/items/resourceChemistry.js
+++ b/src/data/items/resourceChemistry.js
@@ -34,7 +34,7 @@ const BASES = {
 }
 
 export const FABRICATION_POTION_PERCENT = .3;
-export const GRAYTIDING_POTION_PERCENT = .15;
+export const GRAYTIDING_POTION_PERCENT = .30;
 export const TINKERING_POTION_PERCENT = .15;
 export const BOTANY_POTION_PERCENT = .3;
 export const COOKING_POTION_PERCENT = .25;
@@ -76,7 +76,7 @@ const POTIONS = {
 		name: "Energy Drink",
 		sellPrice: 79,
 		icon: require("@/assets/art/chemistry/energy_drink.png"),
-		description: "Whenever you get energy from engineering, also get money of the same amount.",
+		description: "Whenever you get energy from engineering, also get four times that amount of money.",
 		potionJob: "engineering",
 		potionCharges: 10
 	},
@@ -86,7 +86,7 @@ const POTIONS = {
 		icon: require("@/assets/art/chemistry/superglue.png"),
 		description: `${TINKERING_POTION_PERCENT * 100}% chance to obtain one of the kinds of junk not used in a tinkering action.`,
 		potionJob: "tinkering",
-		potionCharges: 10
+		potionCharges: 5
 	},
 	potionXenobiology: {
 		name: "Splitting Agent",

--- a/src/data/upgrades.js
+++ b/src/data/upgrades.js
@@ -148,7 +148,7 @@ export const COMBAT_UPGRADES = {
 	}
 }
 
-export const MINING_UPGRADE_PERCENT = .2;
+export const MINING_UPGRADE_PERCENT = .15;
 const MINING_UPGRADES = {}
 for (let i = 0; i < 5; i++) {
 	let upgrade = {

--- a/src/state/engineering.js
+++ b/src/state/engineering.js
@@ -37,7 +37,7 @@ const engineering = merge(cloneDeep(jobBase), cloneDeep(jobSingleAction), {
 							chance: 1,
 							items: {
 								id: "money",
-								count: originalItems.count
+								count: originalItems.count * 4
 							}
 						}
 					]


### PR DESCRIPTION
Fixes cultist of ratvar name
Changes miner sprite
Edits the null rod sprite with a community suggestion. Thanks zRedwind
Buffs energy drink to x4
Increases money drops off bosses significantly (up to 50,000)
Buffs the super glue to 30%, reduces charges to 5
Increases meat drops off bosses x5-25
Changes instances of dodge to evade
Nerfs mining upgrade to 15% from 20%
Reduces botany sell costs increasing as you go up in tier.Removes the 5 hp bonus from botany foods