### PR TITLE
Switches iron and glass around in mining, fabrication and chemistry - But not in drops.

### DIFF
--- a/src/components/Content/ContentChemistry.vue
+++ b/src/components/Content/ContentChemistry.vue
@@ -55,12 +55,7 @@
               class="mx--2"
               :src="require('@/assets/art/chemistry/chemOil.png')"
             />
-            <b>Bases</b> that make it up, and sometimes you will a special vessel made with
-            <img
-              class="mx--0"
-              :src="require('@/assets/art/mining/SheetGlass.png')"
-            />
-            <b>Glass</b> to hold it.
+            <b>Bases</b> that make it up.
           </span>
           <span>
             You can speed up this process with

--- a/src/components/Content/ContentChemistry.vue
+++ b/src/components/Content/ContentChemistry.vue
@@ -55,7 +55,12 @@
               class="mx--2"
               :src="require('@/assets/art/chemistry/chemOil.png')"
             />
-            <b>Bases</b> that make it up.
+            <b>Bases</b> that make it up, and sometimes you will a special vessel made with
+            <img
+              class="mx--0"
+              :src="require('@/assets/art/mining/SheetGlass.png')"
+            />
+            <b>Glass</b> to hold it.
           </span>
           <span>
             You can speed up this process with

--- a/src/components/Content/ContentMining.vue
+++ b/src/components/Content/ContentMining.vue
@@ -89,7 +89,7 @@
               class="mx--0"
               :src="require('@/assets/art/fabrication/icon.png')"
             />
-            <b>Fabrication</b> might turn it into weapons or something, or maybe the quartermaster just sell it straight for
+            <b>Fabrication</b> might turn it into weapons or something, or you could just sell it straight for
             <img
               class="mx--2"
               :src="require('@/assets/art/misc/coin-padded.png')"

--- a/src/components/Content/ContentMining.vue
+++ b/src/components/Content/ContentMining.vue
@@ -28,7 +28,7 @@
               :src="require('@/assets/art/mining/icon.png')"
             />
             <b>Mine</b> some
-            <img class="mx--2" :src="require('@/assets/art/mining/SheetIron.png')" />
+            <img class="mx--2" :src="require('@/assets/art/mining/SheetGlass.png')" />
             <b>Ore</b>.
           </span>
         </template>
@@ -52,7 +52,19 @@
             <b>Ore</b>.
           </span>
           <span>
-            Of course, you're probably going to want to build some experience up before you go after some of the
+            Beginners start by pounding 
+            <img
+              class="mx--2"
+              :src="require('@/assets/art/mining/OreGlass.png')"
+            />
+            <b>Sand</b> to make some
+            <img
+              class="mx--2"
+              :src="require('@/assets/art/mining/SheetGlass.png')"
+            /> <b>Glass</b>.
+          </span>
+          <span>
+            Of course, you're probably going to need to build some experience up before you go after some of the
             <img
               class="mx--2"
               :src="require('@/assets/art/mining/SheetGold.png')"
@@ -76,10 +88,7 @@
               class="mx--0"
               :src="require('@/assets/art/fabrication/icon.png')"
             />
-            <b>Fabrication</b> might turn it into weapons or something.
-          </span>
-          <span>
-            Or maybe they just sell it straight for
+            <b>Fabrication</b> might turn it into weapons or something, or maybe the quartermaster just sell it straight for
             <img
               class="mx--2"
               :src="require('@/assets/art/misc/coin-padded.png')"

--- a/src/components/Content/ContentMining.vue
+++ b/src/components/Content/ContentMining.vue
@@ -54,7 +54,8 @@
           <span>
             Beginners start by pounding 
             <img
-              class="mx--2"
+              class="mx--0"
+
               :src="require('@/assets/art/mining/OreGlass.png')"
             />
             <b>Sand</b> to make some

--- a/src/components/Content/ContentMining.vue
+++ b/src/components/Content/ContentMining.vue
@@ -28,7 +28,7 @@
               :src="require('@/assets/art/mining/icon.png')"
             />
             <b>Mine</b> some
-            <img class="mx--2" :src="require('@/assets/art/mining/SheetGlass.png')" />
+            <img class="mx--2" :src="require('@/assets/art/mining/SheetIron.png')" />
             <b>Ore</b>.
           </span>
         </template>

--- a/src/data/chemistry.js
+++ b/src/data/chemistry.js
@@ -64,7 +64,7 @@ const POTIONS = {
 		requiredItems: {
 			oxygen: 1,
 			oil: 2,
-			iron: 1
+			glass: 1
 		}
 	},
 	synthPotionGraytiding: {
@@ -118,7 +118,7 @@ const POTIONS = {
 			sacid: 1,
 			mercury: 1,
 			lithium: 1,
-			iron: 1
+			glass: 1
 		}
 	},
 	synthPotionXenobiology: {

--- a/src/data/fabrication.js
+++ b/src/data/fabrication.js
@@ -111,8 +111,8 @@ const ASSAULTMECHS = {
 		xp: 858,
 		requiredLevel: 11,
 		requiredItems: {
-			iron: 90,
-			glass: 20,
+			glass: 90,
+			iron: 20,
 			silver: 20
 		}
 	},
@@ -123,7 +123,7 @@ const ASSAULTMECHS = {
 		xp: 1482,
 		requiredLevel: 19,
 		requiredItems: {
-			glass: 30,
+			iron: 30,
 			silver: 45,
 			gold: 50,
 			titanium: 5
@@ -208,7 +208,7 @@ const ENERGY_AMMO = {
 			count: 8,
 		},
 		requiredItems: {
-			iron: 1
+			glass: 1
 		}
 	},
 	fabricateEammo2: {
@@ -256,7 +256,7 @@ const BALLISTIC_AMMO = {
 			count: 8,
 		},
 		requiredItems: {
-			glass: 1
+			iron: 1
 		}
 	},
 	fabricateBammo2: {
@@ -341,7 +341,7 @@ const BALLISTIC_GUNS = {
 		xp: 20,
 		requiredLevel: 8,
 		requiredItems: {
-			glass: 5
+			iron: 5
 		}
 	},
 	fabricateBgun3: {

--- a/src/data/fabrication.js
+++ b/src/data/fabrication.js
@@ -6,8 +6,8 @@ const MECHS = {
 		xp: 546,
 		requiredLevel: 7,
 		requiredItems: {
-			iron: 100,
-			glass: 20,
+			glass: 100,
+			iron: 20,
 			silver: 10
 		}
 	},
@@ -18,8 +18,8 @@ const MECHS = {
 		xp: 1170,
 		requiredLevel: 15,
 		requiredItems: {
-			iron: 5,
-			glass: 25,
+			glass: 5,
+			iron: 25,
 			silver: 50,
 			gold: 50
 		}

--- a/src/data/graytiding.js
+++ b/src/data/graytiding.js
@@ -358,11 +358,11 @@ const ACTIONS = {
 				chance: 1,
 				itemTable: [
 					{
-						id: "iron",
+						id: "glass",
 						count: [1, 3],
 						weight: 325
 					},{
-						id: "glass",
+						id: "iron",
 						count: [1, 3],
 						weight: 220
 					},{

--- a/src/data/items/resourceMining.js
+++ b/src/data/items/resourceMining.js
@@ -1,13 +1,13 @@
 export default {
-	iron: {
-		name: "Iron",
-		sellPrice: 2,
-		icon: require("@/assets/art/mining/SheetIron.png")
-	},
 	glass: {
 		name: "Glass",
-		sellPrice: 10,
+		sellPrice: 2,
 		icon: require("@/assets/art/mining/SheetGlass.png")
+	},
+	iron: {
+		name: "Iron",
+		sellPrice: 10,
+		icon: require("@/assets/art/mining/SheetIron.png")
 	},
 	silver: {
 		name: "Silver",

--- a/src/data/mining.js
+++ b/src/data/mining.js
@@ -1,15 +1,15 @@
 export const ACTIONS = {
-	mineIron: {
+	mineSand: {
 		time: 1.5,
-		item: "iron",
-		icon: require("@/assets/art/mining/OreIron.png"),
+		item: "glass",
+		icon: require("@/assets/art/mining/OreGlass.png"),
 		xp: .5,
 		requiredLevel: 1
 	},
-	mineSand: {
+	mineIron: {
 		time: 2.0,
-		item: "glass",
-		icon: require("@/assets/art/mining/OreGlass.png"),
+		item: "iron",
+		icon: require("@/assets/art/mining/OreIron.png"),
 		xp: 1,
 		requiredLevel: 5
 	},


### PR DESCRIPTION
Switches iron and glass around, mostly

Reasons:
* Harvesting sand is easier than iron as it is everywhere, better thematically
* The miner guide tells you to pound sand
* Shotguns and shotgun ammo now need iron instead of glass, better thematically
* Base powercells require glass, which better represents how you need some of it in ss13 to actually make cells
* Handily, base mechs getting the ore switched works out better because the first mech you unlock is the ripley with glass cage, using the most glass (100) out of all mechs.

I changed potions that needed iron as an element to now need glass for a "special beaker" (only affects fauna perfume and glue) mostly because I feel like keeping the iron requirement would be a bigger balance change than the ones below.

Things unchaged, resulting in slight buff:
* Supply pod (1000 credits) can still drop 10 iron (100 value) instead of 10 glass (20 value) 
* Miner enemy in arrivals still drops iron instead of glass. This makes the fight slightly more worth it as the miner is not a pushover at the very beginning, plus adds some morbid humour to the roboticist telling you to look for miners that are still alive if you need iron
