### PR TITLE
Health Colors Revamp

### DIFF
--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -122,9 +122,16 @@ export default {
       return this.$store.getters["playerMob/stats"].maxHealth;
     },
     healthClass() {
-      return this.playerHealth == this.playerMaxHealth
-        ? "health-full"
-        : "health-damaged";
+      if (this.playerMaxHealth == this.playerHealth) {
+        return "health-full"
+      }
+      else if (parseInt(this.playerMaxHealth) / 2 < this.playerHealth) {
+        return "health-damaged"
+      }
+      else if (parseInt(this.playerMaxHealth) / 4 < this.playerHealth) {
+        return "health-severe"
+      }
+      else return "health-critical"
     },
     bankItemIds() {
       return this.$store.getters["inventory/bankItemIds"];
@@ -226,8 +233,14 @@ export default {
   font-weight: bold;
 }
 
+.health-critical {
+  color: red;
+}
+.health-severe {
+  color: orange
+}
 .health-damaged {
-  color: rgb(202, 80, 80);
+  color: rgb(197, 197, 0);
 }
 .health-full {
   color: green;


### PR DESCRIPTION
# Health Colors revamp
### Before: 
```
100% = Green
<100% = Red
```
### After:
```
100% = Green
>50% = Yellow
>25% = Orange
<25% = Red
```
The colors are designed to get brighter as your health gets low, to attempt to catch your eye if you are in another screen. Before, it was easy to miss being low on health as it's always red.