### PR TITLE
Allow crafting with equipped items

### DIFF
--- a/src/components/ItemRequirement.vue
+++ b/src/components/ItemRequirement.vue
@@ -2,9 +2,9 @@
   <div class="d-flex flex-row align-items-center">
     <img :src="item.icon" :id="id" class="mx--0" />
     <item-popover :itemId="itemId" :target="id" />
-    <div :style="{opacity: bankCount >= count ? 1: .5}">
+    <div :style="{opacity: itemCount >= count ? 1: .5}">
       <span>x{{count}}</span>
-      <span class="ml-1">({{bankCount ? bankCount : 0 | aggressive}})</span>
+      <span class="ml-1">({{itemCount ? itemCount : 0 | aggressive}})</span>
     </div>
   </div>
 </template>
@@ -20,6 +20,9 @@ export default {
     bank() {
       return this.$store.getters["inventory/bank"];
     },
+    equipment() {
+      return this.$store.getters["inventory/equipment"];
+    },
     id() {
       return this._uid.toString();
     },
@@ -28,7 +31,21 @@ export default {
       return ITEMS[this.itemId];
     },
     bankCount() {
-      return this.bank[this.itemId];
+      return this.bank[this.itemId] || 0;
+    },
+    equipmentCount() {
+      let count = 0;
+      for (let [equipmentId, equipment] of Object.entries(this.equipment)) {
+          let equipmentItemId = equipment.itemId;
+          if (!equipmentItemId || equipmentItemId != this.itemId) continue;
+          count += equipment.count;
+          // No item can be in more than one slot, so we're done.
+          break;
+      }
+      return count;
+    },
+    itemCount() {
+      return this.bankCount + this.equipmentCount;
     }
   }
 };

--- a/src/state/jobSingleAction.js
+++ b/src/state/jobSingleAction.js
@@ -25,6 +25,11 @@ export default {
 				for (let [itemId, requiredCount] of Object.entries(action.requiredItems)) {
 					let count = rootGetters["inventory/bank"][itemId];
 					count = count ? count : 0;
+					for (let [equipmentId, equipment] of Object.entries(rootGetters["inventory/equipment"])) {
+						let equipmentItemId = equipment.itemId;
+						if (!equipmentItemId || equipmentItemId != itemId) continue;
+						count += equipment.count;
+					}
 					if (count < requiredCount) return false;
 				}
 				return true;


### PR DESCRIPTION
This PR will allow players to craft items that require items that are currently equipped for combat such as food and ammunition.

Equipped items are shown on the action panel just the same as if they were part of the player's bank.

**NOTE:** To facilitate this change, I made a change to setter `inventory/changeItemCount` such that it no longer checks if we are trying to change the equipped item's count by a negative amount. I think the only reason for this check was to allow zeroing out bank items when an item was equipped, but I am not completely familiar with the codebase yet. Please sanity check me!

I'm also not 100% happy with the code duplication of `changeItemCount` and `moveBankToEquipment`/`moveEquipmentToBank` and how they modify the bank state, but I couldn't find a cleaner way. Calling `changeItemCount` from either `move` function would cause conflicts given how `changeItemCount` now handles equipped items.