### PR TITLE
Add option to cancel combat when pockets get empty

### DIFF
--- a/src/components/Content/ContentSettings.vue
+++ b/src/components/Content/ContentSettings.vue
@@ -32,6 +32,19 @@
 
             <div class="custom-control custom-switch">
               <input
+                v-model="pocketsEmptyStop"
+                type="checkbox"
+                class="custom-control-input"
+                id="pocketsEmptyStop"
+              />
+              <label
+                class="custom-control-label"
+                for="pocketsEmptyStop"
+              >Stop Combat when Pockets Empty</label>
+            </div>
+
+            <div class="custom-control custom-switch">
+              <input
                 v-model="darkMode"
                 type="checkbox"
                 class="custom-control-input"
@@ -226,6 +239,14 @@ export default {
       },
       set(value) {
         this.$store.commit("settings/setInventoryFullStop", value);
+      }
+    },
+    pocketsEmptyStop: {
+      get() {
+        return this.$store.getters["settings/pocketsEmptyStop"];
+      },
+      set(value) {
+        this.$store.commit("settings/setPocketsEmptyStop", value);
       }
     },
     chronoPanelEnabled: {

--- a/src/state/mob.js
+++ b/src/state/mob.js
@@ -162,6 +162,9 @@ export function createMobModule(mobType) {
 					if (pocket.count == 0) {
 						pocket.itemId = null;
 						EventBus.$emit("toast", { text: `Out of ammo!`, duration: 3000 });
+						if (rootGetters["settings/pocketsEmptyStop"]) {
+							dispatch("cancelAllActions", {}, { root: true });
+						}
 					}
 				}
 			},

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -5,6 +5,7 @@ const settings = {
 	state: {
 		showVirtualLevels: false,
 		inventoryFullStop: true,
+		pocketsEmptyStop: false,
 		autoEatEnabled: true,
 		chronoPanelEnabled: false,
 		darkMode: false
@@ -15,6 +16,9 @@ const settings = {
 		},
 		inventoryFullStop(state) {
 			return state.inventoryFullStop;
+		},
+		pocketsEmptyStop(state) {
+			return state.pocketsEmptyStop;
 		},
 		autoEatEnabled(state) {
 			return state.autoEatEnabled;
@@ -35,6 +39,9 @@ const settings = {
 		},
 		setInventoryFullStop(state, val) {
 			state.inventoryFullStop = val;
+		},
+		setPocketsEmptyStop(state, val) {
+			state.pocketsEmptyStop = val;
 		},
 		setAutoEatEnabled(state, val) {
 			state.autoEatEnabled = val;


### PR DESCRIPTION
This PR will add an extra option to the Settings menu to automatically cancel combat should their pockets become empty (run out of ammo). This setting is set to false by default.

This can help AFK farming sessions from disaster when a player runs out of ammo and finds themselves helpless against the enemy they've chosen to farm. It will, however, destroy all loot upon running out of ammunition, but if players decide to turn this on, their equipment is probably more valuable than their loot.