### PR TITLE
Fixes dissapearing items upon changing equipment.

### DIFF
--- a/src/state/inventory.js
+++ b/src/state/inventory.js
@@ -252,6 +252,18 @@ const inventory = {
 			let prevCount = state.equipment[slot].count;
 
 			let count = getEquipmentStackable(itemId) ? state.bank[itemId] : 1;
+
+			//if an item is equipped, make sure you can unequip it while equippng a new one
+			if (prevItemId) {
+				if (this.getters["inventory/canUnequip"](prevItemId) ||
+						getEquipmentStackable(itemId) || state.bank[itemId] == 1) {
+					;
+				} else {
+					EventBus.$emit("toast", { icon: require('@/assets/art/sidebar/backpack.png'), text: "Your inventory is full!", duration: 4000 });
+					return;
+				}
+			}
+
 			commit("moveBankToEquipment", { slot: slot, itemId, count });
 			dispatch("playerMob/clampHealth", {}, { root: true })
 


### PR DESCRIPTION
When changing equipment with a full inventory, while equipped item is marked as not unequipable, equipping a stacked item from bank causes equipped item to dissapear.

https://cdn.discordapp.com/attachments/726850000125952101/731794284000575548/inventorybug.gif
fireaxe dissapears