### PR TITLE
Increases the lockers protection rating

### DIFF
--- a/src/data/enemies/bridge.js
+++ b/src/data/enemies/bridge.js
@@ -9,8 +9,8 @@ export default {
 			power: 80,
 			evasion: -10,
 			damageType: "brute",
-			burnProtection: 20,
-			bruteProtection: 20
+			burnProtection: 25,
+			bruteProtection: 25
 		},
 		itemTables: [
 			{


### PR DESCRIPTION
The captains locker has been reinforced from 20% armor rating to 25% armor rating. This is to account for the stored propaganga.