### PR TITLE
Fix cooking potion usage

### DIFF
--- a/src/state/cooking.js
+++ b/src/state/cooking.js
@@ -23,7 +23,7 @@ const cooking = merge(cloneDeep(jobBase), cloneDeep(jobSingleAction), {
 			let potion = rootGetters["potions/get"]("cooking");
 			let potionItemId = potion ? potion.itemId : null;
 
-			if (upgradeCount || potionItemId) {
+			if (upgradeCount) {
 
 				let actionEntries = Object.values(actions);
 				actionEntries.forEach((action) => {
@@ -44,13 +44,16 @@ const cooking = merge(cloneDeep(jobBase), cloneDeep(jobSingleAction), {
 					]
 					delete action.item;
 
-					if (upgradeCount) {
-						action.itemTable.push({
-							weight: totalPercent,
-							id: "q_" + originalItem
-						})
-					}
+					action.itemTable.push({
+						weight: totalPercent,
+						id: "q_" + originalItem
+					})
 				})
+			} else {
+				let actionEntries = Object.values(actions);
+				actionEntries.forEach((action) => {
+					action.preservePotion = true;
+				});
 			}
 
 			return actions;


### PR DESCRIPTION
Fixes #240. 

The cooking potion was set to be used if EITHER the fry cooking upgrade or the potion was available. However, due to the way that the potion only augments fry cooking, it is useless on its own.

This PR will set cooking actions to preserve their potion when fry cooking is unavailable or disabled.

(I also removed a redundant if-statement I noticed in the process.)