### PR TITLE
Allow potion use with fry cooking disabled

### DIFF
--- a/src/state/cooking.js
+++ b/src/state/cooking.js
@@ -23,18 +23,17 @@ const cooking = merge(cloneDeep(jobBase), cloneDeep(jobSingleAction), {
 			let potion = rootGetters["potions/get"]("cooking");
 			let potionItemId = potion ? potion.itemId : null;
 
-			if (upgradeCount) {
+			let totalPercent = upgradeCount * COOKING_UPGRADE_PERCENT;
+			if (potionItemId == "potionCooking") {
+				totalPercent += COOKING_POTION_PERCENT;
+			}
 
+			if (totalPercent > 0) {
 				let actionEntries = Object.values(actions);
 				actionEntries.forEach((action) => {
 
 					let originalItem = action.item;
 					delete action.item;
-
-					let totalPercent = upgradeCount * COOKING_UPGRADE_PERCENT;
-					if (potionItemId == "potionCooking") {
-						totalPercent += COOKING_POTION_PERCENT;
-					}
 
 					action.itemTable = [
 						{
@@ -49,11 +48,6 @@ const cooking = merge(cloneDeep(jobBase), cloneDeep(jobSingleAction), {
 						id: "q_" + originalItem
 					})
 				})
-			} else {
-				let actionEntries = Object.values(actions);
-				actionEntries.forEach((action) => {
-					action.preservePotion = true;
-				});
 			}
 
 			return actions;


### PR DESCRIPTION
A follow-up to #267 after further discussion.

Allows the use of the cooking potion even when fry cooking is disabled or not yet unlocked. This still fixes the issue of #240, as cooking potions are consumed and have their intended effect.