### PR TITLE
Add tracking for resets

### DIFF
--- a/src/components/Content/ContentCompletion.vue
+++ b/src/components/Content/ContentCompletion.vue
@@ -7,6 +7,12 @@
     />
     <div class="content-container">
       <div class="row">
+        <div class="col-12 mb-3" v-if="resets > 0">
+          <div class="content-block content-block-top">
+            <img :src="require('@/assets/art/chrono/bluetime.png')" class="mr-2" />
+            <span class="mr-1">Reset Count: {{resets}}</span>
+          </div>
+        </div>
         <div class="col-12">
           <div
             class="content-block content-block-top clickable"
@@ -183,6 +189,9 @@ export default {
     },
     maxLevel() {
       return MAX_LEVEL;
+    },
+    resets() {
+      return this.$store.getters["completion/simulationResetCount"];
     }
   },
   filters: {

--- a/src/state/chrono.js
+++ b/src/state/chrono.js
@@ -137,6 +137,7 @@ const chrono = {
 		},
 		resetSimulation({ getters, commit, dispatch }) {
 			let resetPotential = getters["resetPotential"];
+			this.commit("completion/trackReset");
 			dispatch("resetData", true, { root: true })
 			commit("inventory/changeItemCount", { itemId: "bluetime", count: resetPotential }, { root: true });
 		}

--- a/src/state/completion.js
+++ b/src/state/completion.js
@@ -21,7 +21,8 @@ const completion = {
 		enemies: {
 			// enemyId: count
 		},
-		jobTime: BASE_JOB_TIME
+		jobTime: BASE_JOB_TIME,
+		simulationResetCount: 0
 	},
 	getters: {
 		getItem(state) {
@@ -52,6 +53,9 @@ const completion = {
 			let sum = 0;
 			ALL_JOBS.forEach(job => (sum += Math.min(rootGetters[job.id + "/level"], MAX_LEVEL)));
 			return Math.floor(100 * sum / (ALL_JOBS.length * MAX_LEVEL));
+		},
+		simulationResetCount(state) {
+			return state.simulationResetCount;
 		}
 	},
 	mutations: {
@@ -72,6 +76,9 @@ const completion = {
 		},
 		trackJobTime(state, { jobId, time }) {
 			state.jobTime[jobId] += time;
+		},
+		trackReset(state) {
+			state.simulationResetCount += 1;
 		}
 	}
 }

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -74,15 +74,16 @@ function customMerge(obj, source, root = true, softReset = false) {
 
 	allKeys.forEach(key => {
 		if (key.toLowerCase().includes("coroutine")) return;
-		if (softReset && key == "settings") return;
-		if (softReset && key == "cheats") return;
+		if (softReset && root && key == "settings") return;
+		if (softReset && root && key == "cheats") return;
+		if (softReset && key == "simulationResetCount") return;
 
 		if (!root && obj[key] && obj[key].constructor == Object) {
 			Vue.set(obj, key, {});
 		}
 		if (source[key] && source[key].constructor == Object) {
 			if (!obj[key]) Vue.set(obj, key, {});
-			customMerge(obj[key], source[key], false);
+			customMerge(obj[key], source[key], false, softReset);
 		}
 		else if (Array.isArray(source[key])) {
 			Vue.set(obj, key, []);


### PR DESCRIPTION
This PR will add a small box to the Completion section indicating how many times the player has reset so far. It is not shown before the first reset.

![image](https://user-images.githubusercontent.com/2270586/87256165-3b9aa700-c445-11ea-9e22-95ac0e681c52.png)
