### PR TITLE
Removes luck from 2 cult runes and Fixes Attor Overlay

### DIFF
--- a/src/data/items/slotLimb.js
+++ b/src/data/items/slotLimb.js
@@ -145,6 +145,7 @@ export default {
 		overlay: require("@/assets/art/combat/items/limb/shoe_magboots_overlay.png"),
 		stats: {
 			maxHealth: 120,
+			regen: .3,
 			precision: 0,
 			power: 2,
 			evasion: 2,

--- a/src/data/items/slotNeck.js
+++ b/src/data/items/slotNeck.js
@@ -364,7 +364,6 @@ export default {
 			evasion: 0,
 			precision: 1,
 			power: 3,
-			luck: 2
 		},
 		requires: {
 			evasion: 7
@@ -383,7 +382,6 @@ export default {
 			evasion: 0,
 			precision: 2,
 			power: 6,
-			luck: 4
 		},
 		requires: {
 			evasion: 17
@@ -429,7 +427,7 @@ export default {
 		name: "Rune of Attor",
 		sellPrice: 1500,
 		icon: require("@/assets/art/cult/Huge_rune.png"),
-		overlay: require("@/assets/art/cult/Summon_rune_overlay.png"),
+		overlay: require("@/assets/art/cult/Huge_rune_overlay.png"),
 		overlayAppearInBack: true,
 		overlayRune: true,
 		equipmentSlot: "neck",


### PR DESCRIPTION
Fix: The Rune of Attor has the correct overlay sprite
Nerf/Fix: The first two material cult runes no longer have additional luck.
