### PR TITLE
Increases Cult Pet Times and XP. Fix of 2 typos

### DIFF
--- a/src/data/cargonia.js
+++ b/src/data/cargonia.js
@@ -309,8 +309,8 @@ const RIFLE_GUNS = {
 	buyRgun2: {
 		time: 6,
 		icon: require("@/assets/art/combat/items/hand/gunR_wt5.png"),
-		xp: 18,
-		requiredLevel: 11,
+		xp: 8,
+		requiredLevel: 12,
 		item: "gunRifle2",
 		requiredItems: {
 			money: 420

--- a/src/data/cult.js
+++ b/src/data/cult.js
@@ -130,46 +130,46 @@ const ACTIONS_BRUNE = {
 }
 const ACTIONS_CULTPANION = {
 	sac1: {
-		time: 20,
+		time: 200,
 		item: "companionMousecult",
-		xp: 230,
+		xp: 390,
 		requiredLevel: 13,
-		requiredItems: { unholyfavor: 1 , companionMouse: 1 }
+		requiredItems: { unholyfavor: 12 , companionMouse: 1 }
 	},
 	sac2: {
-		time: 20,
+		time: 200,
 		item: "companionDogcult",
-		xp: 430,
+		xp: 690,
 		requiredLevel: 23,
-		requiredItems: { unholyfavor: 2 , companionDog: 1 }
+		requiredItems: { unholyfavor: 24 , companionDog: 1 }
 	},
 	sac3: {
-		time: 20,
+		time: 200,
 		item: "companionCatcult",
-		xp: 430,
+		xp: 690,
 		requiredLevel: 23,
-		requiredItems: { unholyfavor: 4 , companionCat: 1 }
+		requiredItems: { unholyfavor: 36 , companionCat: 1 }
 	},
 	sac4: {
-		time: 20,
+		time: 200,
 		item: "companionFoxcult",
-		xp: 63,
+		xp: 990,
 		requiredLevel: 33,
-		requiredItems: { unholyfavor: 8 , companionFox: 1 }
+		requiredItems: { unholyfavor: 48 , companionFox: 1 }
 	},
 	sac5: {
-		time: 20,
+		time: 200,
 		item: "companionGoatcult",
-		xp: 830,
+		xp: 1290,
 		requiredLevel: 43,
-		requiredItems: { unholyfavor: 16, companionGoat: 1  }
+		requiredItems: { unholyfavor: 56, companionGoat: 1  }
 	},
 	sac6: {
-		time: 20,
+		time: 200,
 		item: "companionBeecult",
-		xp: 500,
+		xp: 1500,
 		requiredLevel: 50,
-		requiredItems: { unholyfavor: 32, companionBee: 1  }
+		requiredItems: { unholyfavor: 64, companionBee: 1  }
 	},
 }
 

--- a/src/data/ling.js
+++ b/src/data/ling.js
@@ -417,7 +417,7 @@ const ACTIONS_LINGFACE = {
 		}
 	},	
 	lingFace3: {
-		time: 31,
+		time: 9,
 		item: "faceLing3",
 		icon: require("@/assets/art/ling/ling4.png"),
 		xp: 31,
@@ -427,7 +427,7 @@ const ACTIONS_LINGFACE = {
 		}
 	},	
 	lingFace4: {
-		time: 37,
+		time: 9,
 		item: "faceLing4",
 		icon: require("@/assets/art/ling/ling5.png"),
 		xp: 37,
@@ -437,7 +437,7 @@ const ACTIONS_LINGFACE = {
 		}
 	},	
 	lingFace5: {
-		time: 48,
+		time: 9,
 		item: "faceLing5",
 		icon: require("@/assets/art/ling/ling6.png"),
 		xp: 48,


### PR DESCRIPTION
Increases the XP for cult pets sacrifices, as well as changing the times and favor requirements. In general it should be more rewarding to craft them now for XP.

Fixes the xp on the second cargo smuggling action and the action time on the popular disguise.