### PR TITLE
1 Week Traitor Nerf

### DIFF
--- a/src/data/items/slotJumpsuit.js
+++ b/src/data/items/slotJumpsuit.js
@@ -257,18 +257,18 @@ export default {
 		},
 		description: "+50% XP to all default jobs",
 		xpBonuses: {
-			mining: 50,
-			engineering: 50,
-			fabrication: 50,
-			graytiding: 50,
-			tinkering: 50,
-			botany: 50,
-			cooking: 50,
-			bartending: 50,
-			xenobiology: 50,
-			chemistry: 50,
-			shitposting: 50,
-			validhunting: 50
+			mining: 30,
+			engineering: 30,
+			fabrication: 30,
+			graytiding: 30,
+			tinkering: 30,
+			botany: 30,
+			cooking: 30,
+			bartending: 30,
+			xenobiology: 30,
+			chemistry: 30,
+			shitposting: 30,
+			validhunting: 30
 		},
 		requires: {
 			evasion: 1
@@ -276,20 +276,20 @@ export default {
 	},
 	jumpsuitTactical: {
 		name: "Syndicate Jumpsuit",
-		sellPrice: 7777,
+		sellPrice: 4444,
 		equipmentSlot: "jumpsuit",
 		icon: require("@/assets/art/combat/items/jumpsuit_syndicate.png"),
 		overlay: require("@/assets/art/combat/items/jumpsuit_syndicate_overlay.png"),
 		stats: {
-			maxHealth: 77,
-			precision: 7,
-			command: 7,
-			power: 7,
-			evasion: 7,
-			luck: 7
+			maxHealth: 44,
+			precision: 4,
+			command: 4,
+			power: 4,
+			evasion: 4,
+			luck: 4
 		},
 		requires: {
-			evasion: 1
+			command: 4
 		}
 	},
 }

--- a/src/data/traitor.js
+++ b/src/data/traitor.js
@@ -16,7 +16,7 @@ const ONETC = {
 		items:
 		{
 			id: "pillMeth",
-			count: 8888,
+			count: 888,
 		},
 		requiredItems: {
 			spendTC: 1
@@ -30,7 +30,7 @@ const ONETC = {
 		items:
 		{
 			id: "ammoBallistic2",
-			count: 8888,
+			count: 888,
 		},
 		requiredItems: {
 			spendTC: 1
@@ -44,7 +44,7 @@ const ONETC = {
 		items:
 		{
 			id: "ammoEnergy2",
-			count: 8888,
+			count: 888,
 		},
 		requiredItems: {
 			spendTC: 1
@@ -88,7 +88,7 @@ const TWOTC = {
 		items:
 		{
 			id: "foodPasta1",
-			count: 8888,
+			count: 888,
 		},
 		requiredItems: {
 			spendTC: 2
@@ -132,7 +132,7 @@ const THREETC = {
 		items:
 		{
 			id: "drinkSyndicateBomb",
-			count: 8888,
+			count: 888,
 		},
 		requiredItems: {
 			spendTC: 3
@@ -176,7 +176,7 @@ const FOURTC = {
 		items:
 		{
 			id: "slimeRainbow",
-			count: 888,
+			count: 88,
 		},
 		requiredItems: {
 			spendTC: 4


### PR DESCRIPTION
Traitor Nerfs:
Combat Jumpsuit: The jumpsuit has been reduced from 7 in all stats to 4 in all stats, as well as a 4 command requirement. This is still an amazing early game push, but no longer a solid 20+ stat points above other items.

Chameleon Jumpsuit: XP Bonus's have been reduced from 50% to 30%. This could have remained if the rest of the job wasn't such go juice.

Consumables: All non ammo consumables have been reduced by 90%. They were allowing people to completely skip creating food, which was not the intention.