### PR TITLE
Changes how antag job starter items are dropped from crates

### DIFF
--- a/src/components/Content/Shop/ShopPurchase.vue
+++ b/src/components/Content/Shop/ShopPurchase.vue
@@ -102,8 +102,8 @@ export default {
     },
     canOpen() {
       if (!this.item) return false;
-      if (!this.item.itemTable && !this.itemTables) return false;
-      return true;
+      if (this.item.itemTable || this.item.itemTables) return true;
+      return false;
     },
     upgradeChain() {
       if (!this.purchase.upgrade) return [];

--- a/src/data/items/shop.js
+++ b/src/data/items/shop.js
@@ -309,81 +309,95 @@ export default {
 		name: "Revolution Supply Cache",
 		description: "Can be opened",
 		icon: require("@/assets/art/shop/items/revcrate.png"),
-		itemTable: [
+		itemTables: [
 			{
-				id: 'junk',
-				count: [1,25],
-				weight: 25
-			},
-			{
-				id: 'slimeBluespace',
-				weight: 15
+				chance: 0.25,
+				items: {
+					id: 'startCargonia',
+					count: [1,5],
+				}
 			},
 			{
-				id: 'meleeSharp3',
-				count: [1,20],
-				weight: 9
-			},
-			{
-				id: 'headEpic5',
-				weight: 1
-			},
-			{
-				id: 'startCargonia',
-				count: [1,10],
-				weight: 15
-			},
-						{
-				id: 'gunEnergy2',
-				weight: 13
-			},
-			{
-				id: 'meleeBurn1',
-				weight: 12
-			},
-			{
-				id: 'companionPai',
-				weight: 10
-			},
+				chance: 1,
+				itemTable: [
+					{
+						id: 'junk',
+						count: [1,25],
+						weight: 25
+					},
+					{
+						id: 'slimeBluespace',
+						weight: 15
+					},
+					{
+						id: 'meleeSharp3',
+						count: [1,20],
+						weight: 9
+					},
+					{
+						id: 'headEpic5',
+						weight: 1
+					},
+					{
+						id: 'gunEnergy2',
+						weight: 13
+					},
+					{
+						id: 'meleeBurn1',
+						weight: 12
+					},
+					{
+						id: 'companionPai',
+						weight: 10
+					},
+				]
+			}
 		]
 		},
 	secCrate:{
 	name: "Security Crate",
 	description: "Can be opened",
 	icon: require("@/assets/art/shop/items/seccrate.png"),
-	itemTable: [
+	itemTables: [
 		{
-			id: 'faceSecGlassess',
-			weight: 21
+			chance: 0.25,
+			items: {
+				id: 'startLing',
+			}
 		},
 		{
-			id: 'faceSec',
-			weight: 17
-		},
-		{
-			id: 'gunEnergy6',
-			weight: 11
-		},
-		{
-			id: 'meleeBlunt9',
-			weight: 1
-		},
-		{
-			id: 'startLing',
-			weight: 19
-		},
-		{
-			id: 'jumpsuitSecurity',
-			weight: 13
-		},
-		{
-			id: 'meleeBurn2',
-			weight: 10
-		},
-		{
-			id: 'armorSpecial1',
-			weight: 8
-		},
+			chance: 1,
+			itemTable: [
+				{
+					id: 'faceSecGlassess',
+					weight: 21
+				},
+				{
+					id: 'faceSec',
+					weight: 17
+				},
+				{
+					id: 'gunEnergy6',
+					weight: 11
+				},
+				{
+					id: 'meleeBlunt9',
+					weight: 1
+				},
+				{
+					id: 'jumpsuitSecurity',
+					weight: 13
+				},
+				{
+					id: 'meleeBurn2',
+					weight: 10
+				},
+				{
+					id: 'armorSpecial1',
+					weight: 8
+				},
+			]
+		}
 	]
 	},
 	lavaCrate: {


### PR DESCRIPTION
Antag job starter items from crates (for cargonia and ling) are now their own item table independently rolled from the rest of the crate contents
Consequently they are much more likely to drop, with a flat 25% chance to get them from any given crate
Also fixes a bug in the shop menu .vue that broke viewing odds for items with itemTables values
Flash max payout has been reduced, one crate can give up to 5 flashes down from 10

Coderbus also suggested maybe nerfing the flash if this makes them too farmable, I disagree but it's up to the code owners

This PR was inspired by my 20 revolution supply caches with no flashes, and therefore no cargonia :(