### PR TITLE
Minor Bartending Name Changes

### DIFF
--- a/src/data/bartending.js
+++ b/src/data/bartending.js
@@ -574,10 +574,10 @@ const SLIMEPLUS = {
         requiredItems: { power: 1 }
     }, */
     
-Object.values(POWER).forEach(action => action.type = "Virgin");
-Object.values(SLIME).forEach(action => action.type = "Alcoholic");
-Object.values(POWERPLUS).forEach(action => action.type = "Super Virgin");
-Object.values(SLIMEPLUS).forEach(action => action.type = "Super Alcoholic");
+Object.values(POWER).forEach(action => action.type = "Basic Drinks");
+Object.values(SLIME).forEach(action => action.type = "Complex Drinks");
+Object.values(POWERPLUS).forEach(action => action.type = "Super Basic Drinks");
+Object.values(SLIMEPLUS).forEach(action => action.type = "Super Complex Drinks");
 
 export const ACTIONS = {
     ...POWER,


### PR DESCRIPTION
We're all probably tired of hearing about how this drink shouldn't be in that category so I'm just offering to change the drink categories from "Virgin" and "Alcoholic" to "Basic" and "Complex". Maybe now they will stop bugging over it.

Changes:
- "Virgin" is now called "Basic Drinks"
- "Alcoholic" is now called "Complex Drinks"
- "Super Virgin" is now called "Super Basic Drinks"
- "Super Alcoholic" is now called "Super Complex Drinks"

This doesn't change anything pertaining to item codes and from my testing nothing is affected negatively. It seems like the simplest way to fix this without changing everything around and unnecessarily complicating things for the sake of complicating things.