### PR TITLE
Issue 352: Validhunting Tutorial Gamebreaking Runtime

### DIFF
--- a/src/components/Content/ContentCombatJobInfo.vue
+++ b/src/components/Content/ContentCombatJobInfo.vue
@@ -152,25 +152,27 @@
       </li>
     </template>
     <template slot="Robustness?">
-      <span>
-        <img class="mx--0" :src="require('@/assets/art/jobinfo/robustness.png')" />
-        <b>Robustness</b> is a general term for how effective someone or something is in combat, based on their
-        <img
-          class="mx--0"
-          :src="require('@/assets/art/combat/precision.png')"
-        />
-        <img class="mx--1" :src="require('@/assets/art/combat/skull.png')" />
-        <img class="mx--2" :src="require('@/assets/art/combat/black_shoes.png')" />
-        <b>Stats</b>.
-      </span>
-      <span>
-        As a general rule, you shouldn't try to fight enemies that are more
-        <img
-          class="mx--0"
-          :src="require('@/assets/art/jobinfo/robustness.png')"
-        />
-        <b>Robust</b> than you are.
-      </span>
+      <div>
+        <span>
+          <img class="mx--0" :src="require('@/assets/art/jobinfo/robustness.png')" />
+          <b>Robustness</b> is a general term for how effective someone or something is in combat, based on their
+          <img
+            class="mx--0"
+            :src="require('@/assets/art/combat/precision.png')"
+          />
+          <img class="mx--1" :src="require('@/assets/art/combat/skull.png')" />
+          <img class="mx--2" :src="require('@/assets/art/combat/black_shoes.png')" />
+          <b>Stats</b>.
+        </span>
+        <span>
+          As a general rule, you shouldn't try to fight enemies that are more
+          <img
+            class="mx--0"
+            :src="require('@/assets/art/jobinfo/robustness.png')"
+          />
+          <b>Robust</b> than you are.
+        </span>
+      </div>
     </template>
     <template slot="Health?">
       <span>
@@ -466,7 +468,7 @@
 <script>
 import JobInfo from "@/components/Content/JobInfo";
 export default {
-  components: { JobInfo }
+  components: { JobInfo },
 };
 </script>
 

--- a/src/components/Content/ContentCombatJobInfo.vue
+++ b/src/components/Content/ContentCombatJobInfo.vue
@@ -468,7 +468,7 @@
 <script>
 import JobInfo from "@/components/Content/JobInfo";
 export default {
-  components: { JobInfo },
+  components: { JobInfo }
 };
 </script>
 

--- a/src/components/Content/ContentCombatJobInfo.vue
+++ b/src/components/Content/ContentCombatJobInfo.vue
@@ -152,7 +152,7 @@
       </li>
     </template>
     <template slot="Robustness?">
-      <div>
+      <span>
         <span>
           <img class="mx--0" :src="require('@/assets/art/jobinfo/robustness.png')" />
           <b>Robustness</b> is a general term for how effective someone or something is in combat, based on their
@@ -164,15 +164,15 @@
           <img class="mx--2" :src="require('@/assets/art/combat/black_shoes.png')" />
           <b>Stats</b>.
         </span>
-        <span>
-          As a general rule, you shouldn't try to fight enemies that are more
-          <img
-            class="mx--0"
-            :src="require('@/assets/art/jobinfo/robustness.png')"
-          />
-          <b>Robust</b> than you are.
-        </span>
-      </div>
+      </span>
+      <span>
+        As a general rule, you shouldn't try to fight enemies that are more
+        <img
+          class="mx--0"
+          :src="require('@/assets/art/jobinfo/robustness.png')"
+        />
+        <b>Robust</b> than you are.
+      </span>
     </template>
     <template slot="Health?">
       <span>


### PR DESCRIPTION
fixes #352 

Issue: Toggling between Stats? and Robustness? buttons on Validhunting tutorial caused an error.

Cause: The cause of this issue is the Robustness? slot in ContentCombatJobInfo.vue, however after some time looking over it I don't actually know why this error is occurring and would love for someone to explain it if anyone figures it out.
Issue 352: Validhunting Tutorial Gamebreaking Runtime

Fix: There were a couple things that could stop the bug from occurring:
- changing the template tag for Robustness? slot to another tag like div fixes it
- commenting out the two img tags line 163, 164 fixes it
- wrapping the content of the Robustness? slot with a div fixes it.

I went with the 3rd options because it seemed the cleanest/least obtrusive.

I legitimately have no idea why this bug was occurring, but this seems to at least stop it from occurring.