### PR TITLE
Issue 353: fix popover disappearing

### DIFF
--- a/src/components/Content/Combat/RobustnessBadge.vue
+++ b/src/components/Content/Combat/RobustnessBadge.vue
@@ -5,11 +5,11 @@
       :target="id"
       triggers="hover"
       placement="top"
-      delay="0"
-      :customClass="$store.getters['settings/darkModeClass']"
+      delay="50"
+      :customClass="`${$store.getters['settings/darkModeClass']} no-pointer-events`"
     >
       <div class="d-flex flex-column align-items-center">
-				<span class="mb-1 description">Attack Speed: {{getBasedStats.attackSpeed}}</span>
+        <span class="mb-1 description">Attack Speed: {{getBasedStats.attackSpeed}}</span>
         <stats-panel :stats="getBasedStats" />
       </div>
     </b-popover>
@@ -21,7 +21,7 @@ import StatsPanel from "@/components/Content/Combat/StatsPanel";
 import {
   getBasedStats,
   calcRobustness,
-  getRobustnessCssClass
+  getRobustnessCssClass,
 } from "@/utils/combatUtils";
 export default {
   components: { StatsPanel },
@@ -42,8 +42,8 @@ export default {
         calcRobustness(this.$store.getters["playerMob/stats"], "player"),
         this.robustness
       );
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/Content/Combat/StatPanelItem.vue
+++ b/src/components/Content/Combat/StatPanelItem.vue
@@ -9,7 +9,7 @@
       triggers="hover"
       placement="top"
       delay="0"
-      :customClass="$store.getters['settings/darkModeClass']"
+      :customClass="`${$store.getters['settings/darkModeClass']} no-pointer-events`"
     >
       <div class="d-flex flex-column align-items-center">
         <h6>{{name}}</h6>
@@ -29,14 +29,18 @@ export default {
     valueClass() {
       if (!this.value || this.value == 0) return "empty";
       return this.value > 0 ? "positive" : "negative";
-    }
-  }
+    },
+  },
 };
 </script>
 
 <style scoped>
 img {
   width: 32px;
+}
+
+.no-pointer-events {
+  pointer-events: none;
 }
 
 .positive {

--- a/src/components/Content/Combat/StatsPanel.vue
+++ b/src/components/Content/Combat/StatsPanel.vue
@@ -73,7 +73,7 @@
       triggers="hover"
       placement="top"
       delay="0"
-      :customClass="$store.getters['settings/darkModeClass']"
+      :customClass="`${$store.getters['settings/darkModeClass']} no-pointer-events`"
     >
       <div class="d-flex flex-column align-items-center">
         <h6>Damage Type: {{stats.damageType.toUpperCase()}}</h6>
@@ -104,12 +104,15 @@ export default {
     },
     damageTypeImage() {
       return this.stats.damageType == "brute" ? BRUTE_ICON : BURN_ICON;
-    }
-  }
+    },
+  },
 };
 </script>
 
 <style scoped>
+.no-pointer-events {
+  pointer-events: none;
+}
 .stats-panel {
   max-width: 160px;
   min-width: 130px;


### PR DESCRIPTION
fixes #353 

Issue: mousing over a b-popover while within another b-popover causes the initial b-popover to disappear as shown in issue #353 

Cause: the hover event for the higher level b-popover switches to false and the b-popover disappears when you mouse over the other b-popover

Fix: I added pointer-events: none to the most nested b-popover so that the hover event still applies to the main b-popover. I applied this fix to equipment page (shown in gif in issue #353 ) as well as robustness badge.

Additional: Also changed delay from 0 to 50 for robustness badge or else the b-popover for robustness disappears when you try to mouse up over it unless you do it in just the right way.

