### PR TITLE
Enables "Preserve" option.

### DIFF
--- a/src/state/mob.js
+++ b/src/state/mob.js
@@ -171,7 +171,7 @@ export function createMobModule(mobType) {
 				var pocket = rootGetters["inventory/equipment"].pocket;
 				if (state.mobType == "player" && pocket.itemId && !rootGetters["inventory/checkRestricted"](pocket.itemId)) {
 					if (ITEMS[pocket.itemId].preserve == true) { }
-					if(rootGetters["upgrades/get"]("ammoSaver") > 0 && rootGetters["combat/isRanged"]) {
+					else if(rootGetters["upgrades/get"]("ammoSaver") > 0 && rootGetters["combat/isRanged"]) {
 						state.ammoStreak += 1;
 						if(state.ammoStreak == 5){
 							state.ammoStreak = 0;

--- a/src/state/mob.js
+++ b/src/state/mob.js
@@ -170,6 +170,7 @@ export function createMobModule(mobType) {
 				// Use ammo
 				var pocket = rootGetters["inventory/equipment"].pocket;
 				if (state.mobType == "player" && pocket.itemId && !rootGetters["inventory/checkRestricted"](pocket.itemId)) {
+					if (ITEMS[pocket.itemId].preserve == true) { }
 					if(rootGetters["upgrades/get"]("ammoSaver") > 0 && rootGetters["combat/isRanged"]) {
 						state.ammoStreak += 1;
 						if(state.ammoStreak == 5){


### PR DESCRIPTION
This is a single line change, which enables you to specify `preserve: true` in any pocket item. It will not be consumed on attack if this is true. If missing or false, it behaves as normal.