### PR TITLE
Hiding items from completion: "Nocomplete" Item Key

### DIFF
--- a/src/components/Content/ContentCompletion.vue
+++ b/src/components/Content/ContentCompletion.vue
@@ -168,7 +168,7 @@ export default {
       return this._uid.toString();
     },
     items() {
-      return ITEMS;
+      return Object.values(ITEMS).filter(itemId => !itemId.nocomplete);
     },
     enemies() {
       return ENEMIES;

--- a/src/state/completion.js
+++ b/src/state/completion.js
@@ -43,7 +43,6 @@ const completion = {
 		itemPercent(state, getters) {
             let itemsCounted = Object.values(ITEMS).filter(itemId => !itemId.nocomplete);
 			let itemsComplete = Object.keys(ITEMS).filter(itemId => getters.getItem(itemId)).length;
-			console.log(Object.keys(ITEMS).length - itemsCounted.length);
             return Math.floor(100 * itemsComplete / itemsCounted.length);
         },
 		enemyPercent(state, getters) {

--- a/src/state/completion.js
+++ b/src/state/completion.js
@@ -41,9 +41,11 @@ const completion = {
 			}
 		},
 		itemPercent(state, getters) {
+            let itemsCounted = Object.values(ITEMS).filter(itemId => !itemId.nocomplete);
 			let itemsComplete = Object.keys(ITEMS).filter(itemId => getters.getItem(itemId)).length;
-			return Math.floor(100 * itemsComplete / Object.keys(ITEMS).length);
-		},
+			console.log(Object.keys(ITEMS).length - itemsCounted.length);
+            return Math.floor(100 * itemsComplete / itemsCounted.length);
+        },
 		enemyPercent(state, getters) {
 			let enemiesComplete = Object.keys(ENEMIES).filter(enemyId => getters.getEnemy(enemyId))
 				.length;


### PR DESCRIPTION
Thanks to PKPenguin321 for help with this.

This adds the ability to add unobtainable items to the live game without affecting completion.

In an item's keys, where you'd put things such as `name` and `sellPrice`, you can add `nocomplete`, and give it a boolean value of `true` to hide the item from the Completion GUI, and force it to give no % to completion if obtained via cheat menu.

If you don't make the item obtainable through some means, it will be completely invisible to non-cheating players.