### PR TITLE
Nocomplete v2

### DIFF
--- a/src/components/Content/ContentCompletion.vue
+++ b/src/components/Content/ContentCompletion.vue
@@ -168,7 +168,17 @@ export default {
       return this._uid.toString();
     },
     items() {
-      return ITEMS;
+      Object.filter = function(obj, predicate) {
+      let result = {}, key;
+      for (key in obj) {
+        if (obj.hasOwnProperty(key) && !predicate(obj[key])) {
+            result[key] = obj[key];
+        }
+      }
+        return result;
+      };
+      const nocomexclude = Object.filter(ITEMS, itemId => itemId.nocomplete);
+      return nocomexclude;
     },
     enemies() {
       return ENEMIES;

--- a/src/state/completion.js
+++ b/src/state/completion.js
@@ -41,9 +41,10 @@ const completion = {
 			}
 		},
 		itemPercent(state, getters) {
+            let itemsCounted = Object.values(ITEMS).filter(itemId => !itemId.nocomplete).length;
 			let itemsComplete = Object.keys(ITEMS).filter(itemId => getters.getItem(itemId)).length;
-			return Math.floor(100 * itemsComplete / Object.keys(ITEMS).length);
-		},
+            return Math.floor(100 * itemsComplete / itemsCounted);
+        },
 		enemyPercent(state, getters) {
 			let enemiesComplete = Object.keys(ENEMIES).filter(enemyId => getters.getEnemy(enemyId))
 				.length;


### PR DESCRIPTION
It works properly now, had to add an entire process of logic to make it function. Interesting how the previous solution was so obvious and said it would do what we wanted it to do, but it didn't do *all* of it.

# Changes:
- `ContentCompletion.vue`: Added logic to filter the ITEMS object, and used it. Removed the previous "`return ITEMS;`.
- `completion.js`: Changed the `itemPercent` logic to count 100% as "All items besides those marked 'nocomplete'. Note that the items will still give % towards 100%, but you can and will go over if you gave yourself every item in the code.

Let's hope it doesn't break when you push it to live this time. It works fine for me.

# Cool thing to note:
- Change line 180's `itemId.nocomplete` to `!itemId.nocomplete` to only show items marked `nocomplete` in the completion list. Useful for debugging, probably not live.