### PR TITLE
Black Ops Efficiency upgrade locked behind having at least 1 antag job

### DIFF
--- a/src/data/upgrades.js
+++ b/src/data/upgrades.js
@@ -473,7 +473,7 @@ for (let i = 0; i < 5; i++) {
 		requiredItems: {}, // Filled out below
 		requiredLevels: { validhunting: (i + 1) * 10 },
 		upgrade: "antagUpgrade",
-		requiredUpgrades: { antagUpgrade: i }
+		requiredUpgrades: { antagUpgrade: i, antagRoll: 1 }
 	}
 
 	if (i != 0) {


### PR DESCRIPTION
~~Don't merge this yet, haven't tested it. Just a quick and dirty one liner with the web editor atm.~~

Did this because I showed a friend the game and they were really confused what Black Ops Efficiency upgrades would do (they had 0 antag jobs).