### PR TITLE
Propaganda items have functionality tips in their descriptions

### DIFF
--- a/src/data/items/resourceValidhunting.js
+++ b/src/data/items/resourceValidhunting.js
@@ -13,43 +13,43 @@ export default {
 	},
 	ticket10: {
 		name: "Proletariat Propaganda",
-		description: "This propaganda claims that unions are immoral and your contract is fair.",
+		description: "This propaganda claims that unions are immoral and your contract is fair.\n5 of these will allow you to fight a boss in the Worker Site.",
 		sellPrice: 250,
 		icon: require("@/assets/art/validhunting/doc10.png")
 	},
 	ticket1: {
 		name: "Fascist Propaganda",
-		description: "This propaganda claims the security team is here for your protection.",
+		description: "This propaganda claims the security team is here for your protection.\n5 of these will allow you to fight a boss in Brutal Security.",
 		sellPrice: 250,
 		icon: require("@/assets/art/validhunting/doc20.png")
 	},
 	ticket2: {
 		name: "Local Fauna Propaganda",
-		description: "This propaganda claims the orbited planet is safe to visit.",
+		description: "This propaganda claims the orbited planet is safe to visit.\n5 of these will allow you to fight a boss on the Primordial Planet.",
 		sellPrice: 500,
 		icon: require("@/assets/art/validhunting/doc30.png")
 	},
 	ticket40: {
 		name: "Security Propaganda",
-		description: "This propaganda claims Nanotrasen and the Syndicate aren't engaged in armed corporate warfare.",
+		description: "This propaganda claims Nanotrasen and the Syndicate aren't engaged in armed corporate warfare.\n5 of these will allow you to fight a boss from the Syndicate Nuclear Assault Team.",
 		sellPrice: 500,
 		icon: require("@/assets/art/validhunting/doc40.png")
 	},
 	ticket3: {
 		name: "Religious Propaganda",
-		description: "This propaganda claims the veil to the higher realms is stable.",
+		description: "This propaganda claims the veil to the higher realms is stable.\n5 of these will allow you to fight a boss from the Bloodsworn Cultists.",
 		sellPrice: 750,
 		icon: require("@/assets/art/validhunting/doc50.png")
 	},
 	ticket55: {
 		name: "Traitorous Propaganda",
-		description: "This propaganda claims there are no traitors in Nanotrasen ranks and all can be trusted.",
+		description: "This propaganda claims there are no traitors in Nanotrasen ranks and all can be trusted.\n5 of these will allow you to fight a boss from the Rogue Nanotrasen Team.",
 		sellPrice: 750,
 		icon: require("@/assets/art/validhunting/doc55.png")
 	},
 	ticket60: {
 		name: "Causality Propaganda",
-		description: "This propaganda claims magic isn't real and can't hurt you.",
+		description: "This propaganda claims magic isn't real and can't hurt you.\n5 of these will allow you to fight a boss from the Wizard Federation 'Diplomats'.",
 		sellPrice: 1000,
 		icon: require("@/assets/art/validhunting/doc60.png")
 	},


### PR DESCRIPTION
After the original descriptions, they newline and say "5 of these will allow you to fight a boss in/at/on/from the [X]".