### PR TITLE
Fixes a copypaste error

### DIFF
--- a/src/data/recipes.js
+++ b/src/data/recipes.js
@@ -144,7 +144,7 @@ export const RESEARCH_RECIPES_I = {
 		requiredResearchPoints: 750,
 		upgrade: "toolLing",
 		requiredUpgrades: {
-			toolCult: 0
+			toolLing: 0
 		}
 	},
 }


### PR DESCRIPTION
This error makes the Ling tool research not disappear once purchased, oops