### PR TITLE
Top/Side Bar Improvements

### DIFF
--- a/src/assets/GlobalStyle.css
+++ b/src/assets/GlobalStyle.css
@@ -291,6 +291,14 @@ img {
   background-color: rgb(61, 61, 61) !important;
 }
 
+/* Sticks elements to the top of the page as you scroll down and renders them over other elements */
+.sticky {
+	position: -webkit-sticky;
+	position: sticky;
+	top: 0;
+	z-index: 9;
+}
+
 /* I've lost control of my life */
 .shitposting {
 	font-family: "Comic Sans MS", "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;

--- a/src/components/Content/ContentBartending.vue
+++ b/src/components/Content/ContentBartending.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentBotany.vue
+++ b/src/components/Content/ContentBotany.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentCargonia.vue
+++ b/src/components/Content/ContentCargonia.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-2">
+      <div class="row mb-2 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentChemistry.vue
+++ b/src/components/Content/ContentChemistry.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentCooking.vue
+++ b/src/components/Content/ContentCooking.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentCult.vue
+++ b/src/components/Content/ContentCult.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-2">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentEngineering.vue
+++ b/src/components/Content/ContentEngineering.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentFabrication.vue
+++ b/src/components/Content/ContentFabrication.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentGraytiding.vue
+++ b/src/components/Content/ContentGraytiding.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentLing.vue
+++ b/src/components/Content/ContentLing.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-2">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentMining.vue
+++ b/src/components/Content/ContentMining.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-2">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentResearch.vue
+++ b/src/components/Content/ContentResearch.vue
@@ -8,7 +8,7 @@
     <div class="content-container">
 
       <!-- XP bar and chem slot -->
-      <div class="row mb-2">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentSettings.vue
+++ b/src/components/Content/ContentSettings.vue
@@ -106,7 +106,7 @@
                 <label
                   class="custom-control-label"
                   for="showXPNeeded"
-                >Show XP needed to next level in job headers</label>
+                >Show how much XP is needed to level up in XP bars</label>
               </div>
             </div>
 

--- a/src/components/Content/ContentSettings.vue
+++ b/src/components/Content/ContentSettings.vue
@@ -142,6 +142,22 @@
               </div>
             </div>
 
+            <div class="d-flex my-1">
+              <img class="mx--2 mr-1" :src="require('@/assets/art/shitposting/ghost.png')" />
+              <div class="custom-control custom-switch">
+                <input
+                  v-model="hideLockedJobs"
+                  type="checkbox"
+                  class="custom-control-input"
+                  id="hideLockedJobs"
+                />
+                <label
+                  class="custom-control-label"
+                  for="hideLockedJobs"
+                >Hide locked jobs from the sidebar</label>
+              </div>
+            </div>
+
             <button
               type="button"
               class="btn btn-primary my-1 d-block"
@@ -339,6 +355,14 @@ export default {
       },
       set(value) {
         this.$store.commit("settings/setShowCompletionLines", value);
+      }
+    },
+    hideLockedJobs: {
+      get() {
+        return this.$store.getters["settings/hideLockedJobs"];
+      },
+      set(value) {
+        this.$store.commit("settings/setHideLockedJobs", value);
       }
     },
     inventoryFullStop: {

--- a/src/components/Content/ContentSettings.vue
+++ b/src/components/Content/ContentSettings.vue
@@ -95,6 +95,22 @@
             </div>
 
             <div class="d-flex my-1">
+              <img class="mx--2 mr-1" :src="require('@/assets/art/combat/items/cloak/cloakmining.png')" />
+              <div class="custom-control custom-switch">
+                <input
+                  v-model="showXPNeeded"
+                  type="checkbox"
+                  class="custom-control-input"
+                  id="showXPNeeded"
+                />
+                <label
+                  class="custom-control-label"
+                  for="showXPNeeded"
+                >Show XP needed to next level in job headers</label>
+              </div>
+            </div>
+
+            <div class="d-flex my-1">
               <img class="mx--2 mr-1" :src="require('@/assets/art/botany/seed.png')" />
               <div class="custom-control custom-switch">
                 <input
@@ -299,6 +315,14 @@ export default {
       },
       set(value) {
         this.$store.commit("settings/setShowVirtualLevels", value);
+      }
+    },
+    showXPNeeded: {
+      get() {
+        return this.$store.getters["settings/showXPNeeded"];
+      },
+      set(value) {
+        this.$store.commit("settings/setShowXPNeeded", value);
       }
     },
     showFullValues: {

--- a/src/components/Content/ContentSettings.vue
+++ b/src/components/Content/ContentSettings.vue
@@ -58,7 +58,7 @@
                   class="custom-control-input"
                   id="darkMode"
                 />
-                <label class="custom-control-label" for="darkMode">Dark Mode [EXPERIMENTAL!]</label>
+                <label class="custom-control-label" for="darkMode">Dark Mode</label>
               </div>
             </div>
 

--- a/src/components/Content/ContentShitposting.vue
+++ b/src/components/Content/ContentShitposting.vue
@@ -2,7 +2,7 @@
   <div class="shitposting">
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-2">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentTinkering.vue
+++ b/src/components/Content/ContentTinkering.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentTraitor.vue
+++ b/src/components/Content/ContentTraitor.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-2">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ContentXenobiology.vue
+++ b/src/components/Content/ContentXenobiology.vue
@@ -2,7 +2,7 @@
   <div>
     <content-header :text="job.name" :icon="job.icon" :color="job.color" />
     <div class="content-container">
-      <div class="row mb-4">
+      <div class="row mb-4 sticky">
         <div class="col-md-8 col-lg-9 col-xl-10">
           <experience-header :color="job.color" :jobId="jobId" />
         </div>

--- a/src/components/Content/ExperienceHeader.vue
+++ b/src/components/Content/ExperienceHeader.vue
@@ -10,7 +10,8 @@
       </div>
       <div class="d-flex align-items-center">
         <span class="mr-1">XP</span>
-        <span class="p-1 xp rounded">{{Math.round(xp) | cleanNum}}/{{nextLevelXP | cleanNum}}</span>
+        <div v-if="ifShowXPNeeded"><span class="p-1 xp rounded">{{nextLevelXP - Math.round(xp) | cleanNum}} to next level</span></div>
+        <div v-else><span class="p-1 xp rounded">{{Math.round(xp) | cleanNum}}/{{nextLevelXP | cleanNum}}</span></div>
       </div>
     </div>
     <progress-bar style="border-radius: 0 !important" :progress="progress" />
@@ -43,6 +44,9 @@ export default {
         if (!this.$store.getters["settings/showVirtualLevels"])
           level = Math.min(level, MAX_LEVEL);
         return xpFromLevel(level);
+      },
+      ifShowXPNeeded() {
+        return this.$store.getters["settings/showXPNeeded"];
       },
       progress() {
         if (

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -110,10 +110,18 @@ export default {
       return `v${process.env.PACKAGE_VERSION}`;
     },
     nonCombatJobs() {
-      return ALL_JOBS.filter(job => !job.isCombat);
+      if(!this.$store.getters["settings/hideLockedJobs"]){
+        return ALL_JOBS.filter(job => !job.isCombat);
+      } else {
+        return ALL_JOBS.filter(job => !job.isCombat).filter(job => !this.checkJobLocked(job));
+      }
     },
     combatJobs() {
-      return ALL_JOBS.filter(job => job.isCombat);
+      if(!this.$store.getters["settings/hideLockedJobs"]){
+        return ALL_JOBS.filter(job => job.isCombat);
+      } else {
+        return ALL_JOBS.filter(job => job.isCombat).filter(job => !this.checkJobLocked(job));
+      }
     },
     playerHealth() {
       return Math.round(this.$store.getters["playerMob/health"]);

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -11,7 +11,7 @@ const settings = {
 		pocketsEmptyStop: false,
 		autoEatEnabled: true,
 		chronoPanelEnabled: false,
-		darkMode: false,
+		darkMode: true,
 		hideLockedJobs: false
 	},
 	getters: {

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -4,6 +4,7 @@ const settings = {
 	namespaced: true,
 	state: {
 		showVirtualLevels: false,
+		showXPNeeded: false,
 		showFullValues: false,
 		showCompletionLines: false,
 		inventoryFullStop: true,
@@ -15,6 +16,9 @@ const settings = {
 	getters: {
 		showVirtualLevels(state) {
 			return state.showVirtualLevels;
+		},
+		showXPNeeded(state) {
+			return state.showXPNeeded;
 		},
 		showFullValues(state) {
 			return state.showFullValues;
@@ -44,6 +48,9 @@ const settings = {
 	mutations: {
 		setShowVirtualLevels(state, val) {
 			state.showVirtualLevels = val;
+		},
+		setShowXPNeeded(state, val) {
+			state.showXPNeeded = val;
 		},
 		setShowFullValues(state, val) {
 			state.showFullValues = val;

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -11,7 +11,8 @@ const settings = {
 		pocketsEmptyStop: false,
 		autoEatEnabled: true,
 		chronoPanelEnabled: false,
-		darkMode: false
+		darkMode: false,
+		hideLockedJobs: false
 	},
 	getters: {
 		showVirtualLevels(state) {
@@ -43,6 +44,9 @@ const settings = {
 		},
 		darkModeClass(state) {
 			return state.darkMode ? 'dark-mode' : ''
+		},
+		hideLockedJobs(state) {
+			return state.hideLockedJobs;
 		}
 	},
 	mutations: {
@@ -72,6 +76,9 @@ const settings = {
 		},
 		setDarkMode(state, val) {
 			state.darkMode = val;
+		},
+		setHideLockedJobs(state, val) {
+			state.hideLockedJobs = val;
 		}
 	}
 }


### PR DESCRIPTION
"Top bar" meaning the XP bar and potion slot on each job
- The top bar of each job will now stick to the top of the screen as you scroll down
- There is now a setting that will replace the XP counter in the top bar with the XP required to level up
- There is now a setting to hide locked jobs from the sidebar

Previews:
https://user-images.githubusercontent.com/8345184/169980265-be54fcd1-c4b6-4878-8d00-c7be338d33b0.mp4
https://user-images.githubusercontent.com/8345184/169985654-b6a86c19-3ce3-464c-8509-77df5bd236fb.mp4



