### PR TITLE
Validhunting max rerolls hotfix

### DIFF
--- a/src/state/validhunting.js
+++ b/src/state/validhunting.js
@@ -106,7 +106,7 @@ const validhunting = merge(cloneDeep(jobBase), {
 			commit("setNewXpReward", xpReward);
 		},
 		refreshRerolls({state, getters}, rerolls) {
-			state.rerolls += Math.min(getters["maxRerolls"], rerolls);
+			state.rerolls = Math.min(getters["maxRerolls"], getters["getRerolls"] + rerolls);
 		}
 	}
 });


### PR DESCRIPTION
This fix prevents your rerolls from exceeding your max. Oops